### PR TITLE
Use new /contents accessors

### DIFF
--- a/apps/reg/lib/src/scan-security.dart
+++ b/apps/reg/lib/src/scan-security.dart
@@ -14,7 +14,6 @@
 
 import 'dart:convert';
 
-import 'package:archive/archive.dart';
 import 'package:args/command_runner.dart';
 import 'package:registry/registry.dart' as rpc;
 import 'package:yaml/yaml.dart';

--- a/apps/reg/lib/src/scan-security.dart
+++ b/apps/reg/lib/src/scan-security.dart
@@ -45,7 +45,7 @@ class ScanSecurityCommand extends Command {
     }
 
     String versionName = argResults['version'];
-    String filter = argResults['filter'];
+    String filter = argResults['filter'] ?? "";
 
     final channel = rpc.createClientChannel();
     final client = rpc.RegistryClient(channel, options: rpc.callOptions());
@@ -57,13 +57,11 @@ class ScanSecurityCommand extends Command {
       f: (spec) async {
         var format = typeFromMimeType(spec.mimeType);
         if (format == "openapi") {
-          var request = rpc.GetApiSpecRequest()
-            ..name = spec.name
-            ..view = rpc.View.FULL;
-          var fullSpec = await client.getApiSpec(request);
+          var request = rpc.GetApiSpecContentsRequest()
+            ..name = spec.name + "/contents";
+          var fullSpec = await client.getApiSpecContents(request);
           try {
-            var contents =
-                utf8.decode(GZipDecoder().decodeBytes(fullSpec.contents));
+            var contents = utf8.decode(fullSpec.data);
             var doc = loadYaml(contents);
             if (doc["swagger"] != null) {
               // look for openapi v2 security

--- a/viewer/lib/service/service.dart
+++ b/viewer/lib/service/service.dart
@@ -280,19 +280,6 @@ class SpecService {
       throw err;
     }
   }
-
-  Future<ApiSpec> getSpec(String name) {
-    final client = getClient();
-    final request = GetApiSpecRequest();
-    request.name = name;
-    request.view = View.FULL;
-    try {
-      return client.getApiSpec(request, options: callOptions());
-    } catch (err) {
-      print('Caught error: $err');
-      return null;
-    }
-  }
 }
 
 class ArtifactService {
@@ -318,7 +305,6 @@ class ArtifactService {
     final request = ListArtifactsRequest();
     request.parent = parent;
     request.pageSize = limit;
-    request.view = View.FULL;
     if (filter != null) {
       request.filter = filter;
     }


### PR DESCRIPTION
This updates all get/list calls, removing dependencies on View.FULL and instead using the new "/contents" accessors.
