### PR TITLE
Fix most warnings identified by "dart analyze".

### DIFF
--- a/registry/lib/src/_grpc_client_io.dart
+++ b/registry/lib/src/_grpc_client_io.dart
@@ -31,7 +31,7 @@ class ConnectionError extends Error {
 }
 
 bool unset(String s) {
-  return (s == null) || (s == "");
+  return (s == "");
 }
 
 grpc.ClientChannel createClientChannel() {

--- a/registry/lib/src/list.dart
+++ b/registry/lib/src/list.dart
@@ -12,12 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'generated/google/cloud/apigeeregistry/v1/admin_service.pb.dart';
 import 'generated/google/cloud/apigeeregistry/v1/admin_service.pbgrpc.dart';
-import 'generated/google/cloud/apigeeregistry/v1/admin_models.pbenum.dart';
-import 'generated/google/cloud/apigeeregistry/v1/registry_service.pb.dart';
 import 'generated/google/cloud/apigeeregistry/v1/registry_service.pbgrpc.dart';
-import 'generated/google/cloud/apigeeregistry/v1/registry_models.pbenum.dart';
 import 'grpc_client.dart';
 
 void nil() {}

--- a/viewer/lib/components/api_edit.dart
+++ b/viewer/lib/components/api_edit.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'package:flutter/material.dart';
+import 'package:protobuf/protobuf.dart';
 import '../models/selection.dart';
 import '../service/registry.dart';
 import '../helpers/errors.dart';
@@ -136,7 +137,7 @@ class EditAPIFormState extends State<EditAPIForm> {
 
   void save(BuildContext context) {
     if (apiManager?.value != null && _formKey.currentState!.validate()) {
-      final api = apiManager!.value!.clone();
+      final api = apiManager!.value!.deepCopy();
       List<String> paths = [];
       if (api.displayName != displayNameController.text) {
         api.displayName = displayNameController.text;

--- a/viewer/lib/components/api_list.dart
+++ b/viewer/lib/components/api_list.dart
@@ -38,7 +38,8 @@ class _ApiListCardState extends State<ApiListCard> {
     apiService = ApiService();
     pageLoadController = PagewiseLoadController<Api>(
         pageSize: pageSize,
-        pageFuture: ((pageIndex) => apiService!.getApisPage(pageIndex!).then((value) => value!)) as Future<List<Api>> Function(int?)?);
+        pageFuture: ((pageIndex) =>
+            apiService!.getApisPage(pageIndex!).then((value) => value!)));
   }
 
   @override
@@ -142,9 +143,7 @@ class _ApiListViewState extends State<ApiListView> {
     if (index == 0) {
       Future.delayed(const Duration(), () {
         Selection? selection = SelectionProvider.of(context);
-        if ((selection != null) &&
-            ((selection.apiName.value == null) ||
-                (selection.apiName.value == ""))) {
+        if ((selection != null) && (selection.apiName.value == "")) {
           selection.updateApiName(api.name);
           setState(() {
             selectedIndex = 0;

--- a/viewer/lib/components/artifact_delete.dart
+++ b/viewer/lib/components/artifact_delete.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'package:flutter/material.dart';
+import 'package:protobuf/protobuf.dart';
 import '../models/artifact.dart';
 import '../models/selection.dart';
 import '../service/registry.dart';
@@ -43,7 +44,7 @@ class DeleteArtifactFormState extends State<DeleteArtifactForm> {
     selection = SelectionProvider.of(context);
     SelectionProvider.of(context)!.artifactName.addListener(nameChangeListener);
     super.didChangeDependencies();
-    setArtifactName(SelectionProvider.of(context)?.artifactName?.value);
+    setArtifactName(SelectionProvider.of(context)?.artifactName.value);
   }
 
   void setArtifactName(String? name) {
@@ -69,7 +70,7 @@ class DeleteArtifactFormState extends State<DeleteArtifactForm> {
 
   @override
   void dispose() {
-    selection?.artifactName?.removeListener(nameChangeListener);
+    selection?.artifactName.removeListener(nameChangeListener);
     artifactManager?.removeListener(listener);
     stringValueController.dispose();
     super.dispose();
@@ -122,10 +123,10 @@ class DeleteArtifactFormState extends State<DeleteArtifactForm> {
   void delete(BuildContext context) {
     Selection? selection = SelectionProvider.of(context);
     if (artifactManager?.value != null && _formKey.currentState!.validate()) {
-      final artifact = artifactManager!.value!.clone();
+      final artifact = artifactManager!.value!.deepCopy();
       print("deleting $artifact");
       String subject = artifact.subject;
-      artifactManager?.delete(artifact.name)?.then((x) {
+      artifactManager?.delete(artifact.name).then((x) {
         selection!.notifySubscribersOf(subject);
       });
     }

--- a/viewer/lib/components/artifact_detail_lint.dart
+++ b/viewer/lib/components/artifact_detail_lint.dart
@@ -154,11 +154,12 @@ class _LintArtifactCardState extends State<LintArtifactCard> {
                                           .bodyText2!
                                           .copyWith(
                                               color: Theme.of(context)
-                                                  .accentColor)),
+                                                  .primaryColorDark)),
                                   onTap: () async {
-                                    if (await canLaunch(
-                                        problem.problem.ruleDocUri)) {
-                                      await launch(problem.problem.ruleDocUri);
+                                    if (await canLaunchUrl(Uri.parse(
+                                        problem.problem.ruleDocUri))) {
+                                      await launchUrl(Uri.parse(
+                                          problem.problem.ruleDocUri));
                                     } else {
                                       throw 'Could not launch ${problem.problem.ruleDocUri}';
                                     }

--- a/viewer/lib/components/artifact_detail_lintstats.dart
+++ b/viewer/lib/components/artifact_detail_lintstats.dart
@@ -17,8 +17,6 @@ import 'package:registry/registry.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'detail_rows.dart';
 import '../helpers/extensions.dart';
-import '../models/selection.dart';
-import '../models/highlight.dart';
 
 String stringForLocation(LintLocation location) {
   return "[${location.startPosition.lineNumber}:" +
@@ -67,7 +65,7 @@ class _LintStatsArtifactCardState extends State<LintStatsArtifactCard> {
               controller: controller,
               child: ListView.builder(
                 controller: controller,
-                itemCount: lintstats?.problemCounts?.length,
+                itemCount: lintstats?.problemCounts.length,
                 itemBuilder: (BuildContext context, int index) {
                   if (lintstats == null) {
                     return Container();
@@ -97,11 +95,12 @@ class _LintStatsArtifactCardState extends State<LintStatsArtifactCard> {
                                           .bodyText2!
                                           .copyWith(
                                               color: Theme.of(context)
-                                                  .accentColor)),
+                                                  .primaryColorDark)),
                                   onTap: () async {
-                                    if (await canLaunch(
-                                        problemCount.ruleDocUri)) {
-                                      await launch(problemCount.ruleDocUri);
+                                    if (await canLaunchUrl(
+                                        Uri.parse(problemCount.ruleDocUri))) {
+                                      await launchUrl(
+                                          Uri.parse(problemCount.ruleDocUri));
                                     } else {
                                       throw 'Could not launch ${problemCount.ruleDocUri}';
                                     }

--- a/viewer/lib/components/artifact_detail_message.dart
+++ b/viewer/lib/components/artifact_detail_message.dart
@@ -141,8 +141,6 @@ class EntryItem extends StatelessWidget {
       children.add(_buildTiles(context, child));
     }
     return ExpansionTile(
-      //backgroundColor: Theme.of(context).accentColor,
-      //collapsedBackgroundColor: Theme.of(context).highlightColor,
       key: PageStorageKey<Entry>(root),
       title: entryRow(root),
       children: children,

--- a/viewer/lib/components/artifact_detail_string.dart
+++ b/viewer/lib/components/artifact_detail_string.dart
@@ -51,7 +51,9 @@ class StringArtifactCard extends StatelessWidget {
       child: Column(
         children: [
           ResourceNameButtonRow(
-              name: artifact.name.last(1), show: selflink as void Function()?, edit: editableFn as void Function()?),
+              name: artifact.name.last(1),
+              show: selflink as void Function()?,
+              edit: editableFn as void Function()?),
           Padding(
             padding: EdgeInsets.fromLTRB(16, 0, 16, 0),
             child: Column(
@@ -59,8 +61,8 @@ class StringArtifactCard extends StatelessWidget {
                 SizedBox(height: 30),
                 Linkify(
                   onOpen: (link) async {
-                    if (await canLaunch(link.url)) {
-                      await launch(link.url);
+                    if (await canLaunchUrl(Uri.parse(link.url))) {
+                      await launchUrl(Uri.parse(link.url));
                     } else {
                       throw 'Could not launch $link';
                     }
@@ -69,7 +71,7 @@ class StringArtifactCard extends StatelessWidget {
                   textAlign: TextAlign.left,
                   style: style,
                   linkStyle:
-                      style.copyWith(color: Theme.of(context).accentColor),
+                      style.copyWith(color: Theme.of(context).primaryColorDark),
                 ),
               ],
             ),

--- a/viewer/lib/components/artifact_edit.dart
+++ b/viewer/lib/components/artifact_edit.dart
@@ -14,6 +14,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:protobuf/protobuf.dart';
 import 'package:registry/registry.dart';
 import '../models/selection.dart';
 import '../models/artifact.dart';
@@ -59,7 +60,7 @@ class EditArtifactFormState extends State<EditArtifactForm> {
     selection = SelectionProvider.of(context);
     selection!.artifactName.addListener(selectionListener);
     super.didChangeDependencies();
-    setArtifactName(SelectionProvider.of(context)?.artifactName?.value);
+    setArtifactName(SelectionProvider.of(context)?.artifactName.value);
   }
 
   // Create a global key that uniquely identifies the Form widget
@@ -140,13 +141,13 @@ class EditArtifactFormState extends State<EditArtifactForm> {
   void save(BuildContext context) {
     Selection? selection = SelectionProvider.of(context);
     if (artifactManager?.value != null && _formKey.currentState!.validate()) {
-      final artifact = artifactManager!.value!.clone();
+      final artifact = artifactManager!.value!.deepCopy();
       if (artifact.stringValue != stringValueController.text) {
         artifact.stringValue = stringValueController.text;
       }
       artifactManager
           ?.update(artifact, onError(context))
-          ?.then((Artifact artifact) {
+          .then((Artifact artifact) {
         selection!.notifySubscribersOf(artifact.subject);
       });
     }

--- a/viewer/lib/components/artifact_list.dart
+++ b/viewer/lib/components/artifact_list.dart
@@ -50,7 +50,9 @@ class _ArtifactListCardState extends State<ArtifactListCard> {
     artifactService = ArtifactService();
     pageLoadController = PagewiseLoadController<Artifact>(
         pageSize: pageSize,
-        pageFuture: ((pageIndex) => artifactService!.getArtifactsPage(pageIndex!).then((value) => value!)) as Future<List<Artifact>> Function(int?)?);
+        pageFuture: ((pageIndex) => artifactService!
+            .getArtifactsPage(pageIndex!)
+            .then((value) => value!)));
   }
 
   void selectionListener() {
@@ -234,8 +236,8 @@ class _ArtifactListViewState extends State<ArtifactListView> {
                 icon: Icon(Icons.info),
                 tooltip: "info",
                 onPressed: () async {
-                  if (await canLaunch(artifactInfoLink!)) {
-                    await launch(artifactInfoLink);
+                  if (await canLaunchUrl(Uri.parse(artifactInfoLink!))) {
+                    await launchUrl(Uri.parse(artifactInfoLink));
                   } else {
                     throw 'Could not launch $artifactInfoLink';
                   }

--- a/viewer/lib/components/custom_search_box.dart
+++ b/viewer/lib/components/custom_search_box.dart
@@ -57,7 +57,7 @@ class CustomSearchBoxState extends State<CustomSearchBox> {
         onSubmitted: (s) {
           ObservableString? filter = ObservableStringProvider.of(context);
           if (filter != null) {
-            if ((s == null) | (s == "")) {
+            if (s == "") {
               filter.update(""); // no filter specified
             } else if (s[0] == "=") {
               filter.update(s.substring(1)); // filter is a CEL expression

--- a/viewer/lib/components/detail_rows.dart
+++ b/viewer/lib/components/detail_rows.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -59,7 +57,7 @@ class ResourceNameButtonRow extends StatelessWidget {
                   style: Theme.of(context)
                       .textTheme
                       .bodyText1!
-                      .copyWith(color: Theme.of(context).accentColor),
+                      .copyWith(color: Theme.of(context).primaryColorDark),
                   softWrap: false,
                   overflow: TextOverflow.clip,
                 ),
@@ -73,7 +71,7 @@ class ResourceNameButtonRow extends StatelessWidget {
                 style: Theme.of(context)
                     .textTheme
                     .bodyText1!
-                    .copyWith(color: Theme.of(context).accentColor),
+                    .copyWith(color: Theme.of(context).primaryColorDark),
                 textAlign: TextAlign.right,
               ),
               onTap: edit != null ? edit : () {},
@@ -128,7 +126,7 @@ class TitleRow extends StatelessWidget {
                       style: Theme.of(context)
                           .textTheme
                           .headline3!
-                          .copyWith(color: Theme.of(context).accentColor),
+                          .copyWith(color: Theme.of(context).primaryColorDark),
                       textAlign: TextAlign.left,
                       softWrap: true,
                     ),
@@ -196,8 +194,8 @@ class LinkifiedBodyRow extends StatelessWidget {
     final textStyle = style ?? Theme.of(context).textTheme.bodyText1!;
     return Linkify(
       onOpen: (link) async {
-        if (await canLaunch(link.url)) {
-          await launch(link.url);
+        if (await canLaunchUrl(Uri.parse(link.url))) {
+          await launchUrl(Uri.parse(link.url));
         } else {
           throw 'Could not launch $link';
         }
@@ -205,7 +203,7 @@ class LinkifiedBodyRow extends StatelessWidget {
       text: text,
       textAlign: TextAlign.left,
       style: textStyle,
-      linkStyle: textStyle.copyWith(color: Theme.of(context).accentColor),
+      linkStyle: textStyle.copyWith(color: Theme.of(context).primaryColorDark),
       softWrap: false,
       overflow: TextOverflow.clip,
     );
@@ -225,12 +223,12 @@ class LinkRow extends StatelessWidget {
             child: Text(
               text,
               style: GoogleFonts.inconsolata()
-                  .copyWith(color: Theme.of(context).accentColor),
+                  .copyWith(color: Theme.of(context).primaryColorDark),
               textAlign: TextAlign.left,
             ),
             onTap: () async {
-              if (await canLaunch(url)) {
-                await launch(url);
+              if (await canLaunchUrl(Uri.parse(url))) {
+                await launchUrl(Uri.parse(url));
               } else {
                 throw 'Could not launch $url';
               }
@@ -337,7 +335,7 @@ class LabelsRow extends StatelessWidget {
       children: <Widget>[
         for (var key in keys)
           Chip(
-            backgroundColor: Theme.of(context).accentColor,
+            backgroundColor: Theme.of(context).primaryColorDark,
             label: Text(
               labelText(key, map[key]),
               style: GoogleFonts.inconsolata()

--- a/viewer/lib/components/error_alerts.dart
+++ b/viewer/lib/components/error_alerts.dart
@@ -24,7 +24,7 @@ showErrorAlert(BuildContext context, String message) {
           content: new Text(
               "The signed-in account does not have access to the necessary resources."),
           actions: <Widget>[
-            new FlatButton(
+            new TextButton(
               child: new Text("Close"),
               onPressed: () {
                 Navigator.of(context).pop();
@@ -37,7 +37,7 @@ showErrorAlert(BuildContext context, String message) {
         title: new Text("A problem:"),
         content: new Text(message),
         actions: <Widget>[
-          new FlatButton(
+          new TextButton(
             child: new Text("Close"),
             onPressed: () {
               Navigator.of(context).pop();

--- a/viewer/lib/components/help_dialog.dart
+++ b/viewer/lib/components/help_dialog.dart
@@ -22,7 +22,7 @@ void showHelp(context) {
         title: new Text("Help"),
         content: new Text(""),
         actions: <Widget>[
-          new FlatButton(
+          new TextButton(
             child: new Text("Close"),
             onPressed: () {
               Navigator.of(context).pop();

--- a/viewer/lib/components/pagewise.dart
+++ b/viewer/lib/components/pagewise.dart
@@ -391,7 +391,7 @@ class PagewiseLoadController<T> extends ChangeNotifier {
       }
 
       // Get length accounting for possible null Future return. We'l treat a null Future as an empty return
-      final int length = (page?.length ?? 0);
+      final int length = page.length;
 
       if (length > this.pageSize!) {
         this._isFetching = false;

--- a/viewer/lib/components/project_edit.dart
+++ b/viewer/lib/components/project_edit.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'package:flutter/material.dart';
+import 'package:protobuf/protobuf.dart';
 import '../models/selection.dart';
 import '../service/registry.dart';
 import '../helpers/errors.dart';
@@ -136,7 +137,7 @@ class EditProjectFormState extends State<EditProjectForm> {
 
   void save(BuildContext context) {
     if (projectManager?.value != null && _formKey.currentState!.validate()) {
-      final project = projectManager!.value!.clone();
+      final project = projectManager!.value!.deepCopy();
       List<String> paths = [];
       if (project.displayName != displayNameController.text) {
         project.displayName = displayNameController.text;

--- a/viewer/lib/components/project_list.dart
+++ b/viewer/lib/components/project_list.dart
@@ -121,9 +121,7 @@ class _ProjectListViewState extends State<ProjectListView> {
     if (index == 0) {
       Future.delayed(const Duration(), () {
         Selection? selection = SelectionProvider.of(context);
-        if ((selection != null) &&
-            ((selection.projectName.value == null) ||
-                (selection.projectName.value == ""))) {
+        if ((selection != null) && (selection.projectName.value == "")) {
           selection.updateProjectName(project.name);
           setState(() {
             selectedIndex = 0;

--- a/viewer/lib/components/spec_edit.dart
+++ b/viewer/lib/components/spec_edit.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'package:flutter/material.dart';
+import 'package:protobuf/protobuf.dart';
 import '../models/selection.dart';
 import '../service/registry.dart';
 import '../helpers/errors.dart';
@@ -127,7 +128,7 @@ class EditSpecFormState extends State<EditSpecForm> {
 
   void save(BuildContext context) {
     if (specManager?.value != null && _formKey.currentState!.validate()) {
-      final spec = specManager!.value!.clone();
+      final spec = specManager!.value!.deepCopy();
       List<String> paths = [];
       if (spec.description != descriptionController.text) {
         spec.description = descriptionController.text;

--- a/viewer/lib/components/spec_file.dart
+++ b/viewer/lib/components/spec_file.dart
@@ -15,12 +15,10 @@
 import 'dart:convert';
 import 'package:archive/archive.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:registry/registry.dart';
 import 'package:split_view/split_view.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'package:flutter/foundation.dart';
 import '../helpers/renderer.dart';
 import '../components/detail_rows.dart';
 import '../components/spec_outline.dart';
@@ -64,9 +62,7 @@ class _SpecFileCardState extends State<SpecFileCard> {
   void managerListener() {
     setState(() {
       ApiSpec? spec = specManager?.value;
-      if ((spec != null) &&
-          (spec.contents != null) &&
-          (spec.contents.length > 0)) {
+      if ((spec != null) && (spec.contents.length > 0)) {
         if (spec.mimeType.contains("+gzip")) {
           final data = GZipDecoder().decodeBytes(spec.contents);
           this.body = Utf8Codec().decoder.convert(data);
@@ -195,7 +191,8 @@ class _SpecFileCardState extends State<SpecFileCard> {
                       var address = rendererServiceAddress();
                       if ((address != "SPEC_RENDERER_SERVICE") &&
                           (address != "")) {
-                        launch(address + "/" + specManager!.value!.name);
+                        launchUrl(Uri.parse(
+                            address + "/" + specManager!.value!.name));
                       } else {
                         AlertDialog alert = AlertDialog(
                           content: Text("Spec renderer service not configured"),
@@ -244,7 +241,7 @@ class _SpecFileCardState extends State<SpecFileCard> {
                     width: double.infinity,
                     child: Scrollbar(
                       controller: listScrollController,
-                      isAlwaysShown: true,
+                      thumbVisibility: true,
                       child: MeasureSize(
                         onChange: (size) {
                           listHeight = size.height;
@@ -362,7 +359,7 @@ class _CodeViewState extends State<CodeView> {
     lines = splitLines(widget.text!);
     return Scrollbar(
       controller: scrollController,
-      isAlwaysShown: true,
+      thumbVisibility: true,
       child: ListView.builder(
         itemBuilder: (context, i) {
           return rowForText(i, lines[i]);

--- a/viewer/lib/components/spec_list.dart
+++ b/viewer/lib/components/spec_list.dart
@@ -38,7 +38,8 @@ class _SpecListCardState extends State<SpecListCard> {
     specService = SpecService();
     pageLoadController = PagewiseLoadController<ApiSpec>(
         pageSize: pageSize,
-        pageFuture: ((pageIndex) => specService!.getSpecsPage(pageIndex!).then((value) => value!)) as Future<List<ApiSpec>> Function(int?)?);
+        pageFuture: ((pageIndex) =>
+            specService!.getSpecsPage(pageIndex!).then((value) => value!)));
   }
 
   @override
@@ -142,9 +143,7 @@ class _SpecListViewState extends State<SpecListView> {
     if (index == 0) {
       Future.delayed(const Duration(), () {
         Selection? selection = SelectionProvider.of(context);
-        if ((selection != null) &&
-            ((selection.specName.value == null) ||
-                (selection.specName.value == ""))) {
+        if ((selection != null) && (selection.specName.value == "")) {
           selection.updateSpecName(spec.name);
           setState(() {
             selectedIndex = 0;

--- a/viewer/lib/components/spec_outline.dart
+++ b/viewer/lib/components/spec_outline.dart
@@ -39,9 +39,7 @@ class _SpecOutlineCardState extends State<SpecOutlineCard> {
   void managerListener() {
     setState(() {
       ApiSpec? spec = specManager?.value;
-      if ((spec != null) &&
-          (spec.contents != null) &&
-          (spec.contents.length > 0)) {
+      if ((spec != null) && (spec.contents.length > 0)) {
         if (spec.mimeType.contains("+gzip")) {
           final bytes = GZipDecoder().decodeBytes(spec.contents);
           this.body = Utf8Codec().decoder.convert(bytes);
@@ -176,8 +174,6 @@ class EntryItem extends StatelessWidget {
       children.add(_buildTiles(context, child));
     }
     return ExpansionTile(
-      //backgroundColor: Theme.of(context).accentColor,
-      //collapsedBackgroundColor: Theme.of(context).highlightColor,
       key: PageStorageKey<Entry>(root),
       title: entryRow(root),
       children: children,

--- a/viewer/lib/components/version_edit.dart
+++ b/viewer/lib/components/version_edit.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'package:flutter/material.dart';
+import 'package:protobuf/protobuf.dart';
 import '../models/selection.dart';
 import '../service/registry.dart';
 import '../helpers/errors.dart';
@@ -145,7 +146,7 @@ class EditVersionFormState extends State<EditVersionForm> {
 
   void save(BuildContext context) {
     if (versionManager?.value != null && _formKey.currentState!.validate()) {
-      final version = versionManager!.value!.clone();
+      final version = versionManager!.value!.deepCopy();
       List<String> paths = [];
       if (version.displayName != displayNameController.text) {
         version.displayName = displayNameController.text;

--- a/viewer/lib/components/version_list.dart
+++ b/viewer/lib/components/version_list.dart
@@ -39,7 +39,9 @@ class _VersionListCardState extends State<VersionListCard> {
     versionService = VersionService();
     pageLoadController = PagewiseLoadController<ApiVersion>(
         pageSize: pageSize,
-        pageFuture: ((pageIndex) => versionService!.getVersionsPage(pageIndex!).then((value) => value!)) as Future<List<ApiVersion>> Function(int?)?);
+        pageFuture: ((pageIndex) => versionService!
+            .getVersionsPage(pageIndex!)
+            .then((value) => value!)));
   }
 
   @override
@@ -143,9 +145,7 @@ class _VersionListViewState extends State<VersionListView> {
     if (index == 0) {
       Future.delayed(const Duration(), () {
         Selection? selection = SelectionProvider.of(context);
-        if ((selection != null) &&
-            ((selection.versionName.value == null) ||
-                (selection.versionName.value == ""))) {
+        if ((selection != null) && (selection.versionName.value == "")) {
           selection.updateVersionName(version.name);
           setState(() {
             selectedIndex = 0;

--- a/viewer/lib/helpers/theme.dart
+++ b/viewer/lib/helpers/theme.dart
@@ -19,7 +19,6 @@ ThemeData appTheme() {
     // Define the default brightness and colors.
     brightness: Brightness.light,
     primaryColor: Colors.red[900],
-    accentColor: Colors.blueGrey,
 
     // Define the default font family.
     fontFamily: 'Roboto',

--- a/viewer/lib/models/highlight.dart
+++ b/viewer/lib/models/highlight.dart
@@ -39,9 +39,7 @@ class ObservableHighlightProvider extends InheritedWidget {
 
   const ObservableHighlightProvider(
       {Key? key, required this.observable, required Widget child})
-      : assert(observable != null),
-        assert(child != null),
-        super(key: key, child: child);
+      : super(key: key, child: child);
 
   static ObservableHighlight? of(BuildContext context) => context
       .dependOnInheritedWidgetOfExactType<ObservableHighlightProvider>()

--- a/viewer/lib/models/selection.dart
+++ b/viewer/lib/models/selection.dart
@@ -103,9 +103,7 @@ class SelectionProvider extends InheritedWidget {
 
   const SelectionProvider(
       {Key? key, required this.selection, required Widget child})
-      : assert(selection != null),
-        assert(child != null),
-        super(key: key, child: child);
+      : super(key: key, child: child);
 
   static Selection? of(BuildContext context) => context
       .dependOnInheritedWidgetOfExactType<SelectionProvider>()

--- a/viewer/lib/models/string.dart
+++ b/viewer/lib/models/string.dart
@@ -26,9 +26,7 @@ class ObservableStringProvider extends InheritedWidget {
 
   const ObservableStringProvider(
       {Key? key, required this.observable, required Widget child})
-      : assert(observable != null),
-        assert(child != null),
-        super(key: key, child: child);
+      : super(key: key, child: child);
 
   static ObservableString? of(BuildContext context) => context
       .dependOnInheritedWidgetOfExactType<ObservableStringProvider>()

--- a/viewer/lib/pages/api_list.dart
+++ b/viewer/lib/pages/api_list.dart
@@ -42,7 +42,8 @@ class _ApiListPageState extends State<ApiListPage> {
     apiService = ApiService();
     pageLoadController = PagewiseLoadController<Api>(
         pageSize: pageSize,
-        pageFuture: ((pageIndex) => apiService!.getApisPage(pageIndex!).then((value) => value!)) as Future<List<Api>> Function(int?)?);
+        pageFuture: ((pageIndex) =>
+            apiService!.getApisPage(pageIndex!).then((value) => value!)));
   }
 
   // convert /projects/{project}/locations/global/apis

--- a/viewer/lib/pages/artifact_list.dart
+++ b/viewer/lib/pages/artifact_list.dart
@@ -42,7 +42,9 @@ class _ArtifactListPageState extends State<ArtifactListPage> {
     artifactService = ArtifactService();
     pageLoadController = PagewiseLoadController<Artifact>(
         pageSize: pageSize,
-        pageFuture: ((pageIndex) => artifactService!.getArtifactsPage(pageIndex!).then((value) => value!)) as Future<List<Artifact>> Function(int?)?);
+        pageFuture: ((pageIndex) => artifactService!
+            .getArtifactsPage(pageIndex!)
+            .then((value) => value!)));
   }
 
   // convert /projects/{project}/locations/global/artifacts to projects/{project}/locations/global

--- a/viewer/lib/pages/spec_list.dart
+++ b/viewer/lib/pages/spec_list.dart
@@ -42,7 +42,10 @@ class _SpecListPageState extends State<SpecListPage> {
     specService = SpecService();
     pageLoadController = PagewiseLoadController<ApiSpec>(
         pageSize: pageSize,
-        pageFuture: ((pageIndex) => this.specService!.getSpecsPage(pageIndex!).then((value) => value!)) as Future<List<ApiSpec>> Function(int?)?);
+        pageFuture: ((pageIndex) => this
+            .specService!
+            .getSpecsPage(pageIndex!)
+            .then((value) => value!)));
   }
 
   // convert /projects/{project}/locations/global/apis/{api}/versions/{version}/specs

--- a/viewer/lib/pages/version_list.dart
+++ b/viewer/lib/pages/version_list.dart
@@ -42,7 +42,9 @@ class _VersionListPageState extends State<VersionListPage> {
     versionService = VersionService();
     pageLoadController = PagewiseLoadController<ApiVersion>(
         pageSize: pageSize,
-        pageFuture: ((pageIndex) => versionService!.getVersionsPage(pageIndex!).then((value) => value!)) as Future<List<ApiVersion>> Function(int?)?);
+        pageFuture: ((pageIndex) => versionService!
+            .getVersionsPage(pageIndex!)
+            .then((value) => value!)));
   }
 
   // convert /projects/{project}/locations/global/apis/{api}/versions

--- a/viewer/lib/service/registry.dart
+++ b/viewer/lib/service/registry.dart
@@ -31,9 +31,7 @@ class RegistryProvider extends InheritedWidget {
 
   const RegistryProvider(
       {Key? key, required this.registry, required Widget child})
-      : assert(registry != null),
-        assert(child != null),
-        super(key: key, child: child);
+      : super(key: key, child: child);
 
   static Registry? of(BuildContext context) =>
       context.dependOnInheritedWidgetOfExactType<RegistryProvider>()?.registry;
@@ -255,7 +253,8 @@ class SpecManager extends ResourceManager<ApiSpec> {
 
 class ArtifactManager extends ResourceManager<Artifact> {
   ArtifactManager(String? name) : super(name);
-  Future<Artifact> fetchFuture(RegistryClient client, AdminClient? adminClient) {
+  Future<Artifact> fetchFuture(
+      RegistryClient client, AdminClient? adminClient) {
     final request = GetArtifactRequest();
     request.name = name!;
     return client.getArtifact(request, options: callOptions()).then((artifact) {

--- a/viewer/pubspec.lock
+++ b/viewer/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,21 +28,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
@@ -63,7 +56,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   ffi:
     dependency: transitive
     description:
@@ -218,28 +211,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   path_provider:
     dependency: transitive
     description:
@@ -342,7 +335,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   split_view:
     dependency: "direct main"
     description:
@@ -370,21 +363,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.12"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
- Remove unused imports
- Remove impossible conditions (e.g. checks that non-nullable values are null)
- Remove unnecessary type casts
- Replace calls to deprecated methods with preferred versions