### PR TITLE
Use the universal_html package to fix a dart analyze warning.

### DIFF
--- a/viewer/lib/helpers/_renderer_web.dart
+++ b/viewer/lib/helpers/_renderer_web.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:html' as html;
+import 'package:universal_html/html.dart' as html;
 
 String rendererServiceAddress() {
   return html

--- a/viewer/pubspec.lock
+++ b/viewer/pubspec.lock
@@ -29,6 +29,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.1"
+  charcode:
+    dependency: transitive
+    description:
+      name: charcode
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -50,6 +57,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.2"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.17.2"
   fake_async:
     dependency: transitive
     description:
@@ -163,6 +177,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.2"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.15.0"
   http:
     dependency: "direct main"
     description:
@@ -385,6 +406,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.1"
+  universal_html:
+    dependency: "direct main"
+    description:
+      name: universal_html
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.8"
+  universal_io:
+    dependency: transitive
+    description:
+      name: universal_io
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
   url_launcher:
     dependency: "direct main"
     description:

--- a/viewer/pubspec.yaml
+++ b/viewer/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
   intl: ^0.17.0
   protobuf: ^2.1.0
   split_view: ^2.1.1
+  universal_html: ^2.0.8
   url_launcher: ^6.1.6
   yaml: ^3.1.1
   registry:


### PR DESCRIPTION
Fixes this warning: "Avoid using web-only libraries outside Flutter web plugin packages"

https://stackoverflow.com/a/60646794/35844