### PR TITLE
Move class initialization into constructor to fix mutability warning.

### DIFF
--- a/viewer/lib/components/artifact_detail_message.dart
+++ b/viewer/lib/components/artifact_detail_message.dart
@@ -25,15 +25,14 @@ class MessageArtifactCard extends StatelessWidget {
   final Artifact artifact;
   final GeneratedMessage message;
   final Function? selflink;
-  MessageArtifactCard(this.artifact, this.message, {this.selflink});
-  List<Entry> data = [];
+  final List<Entry> data;
+
+  MessageArtifactCard(this.artifact, this.message, {this.selflink})
+      : data = parseDoc(loadYamlNode(jsonEncode(message.toProto3Json())), 0);
+
   final ScrollController scrollController = ScrollController();
 
   Widget build(BuildContext context) {
-    String json = jsonEncode(message.toProto3Json());
-    YamlNode doc = loadYamlNode(json);
-    data = parseDoc(doc, 0);
-
     return Card(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
Fixes this warning:
   info • lib/components/artifact_detail_message.dart:24:7 • This class (or a class that this class inherits from) is marked as '@immutable', but one or more of its instance fields aren't final: MessageArtifactCard.data • must_be_immutable