### PR TITLE
Shorten text in tab titles to improve views in small windows.

### DIFF
--- a/viewer/lib/pages/api_detail.dart
+++ b/viewer/lib/pages/api_detail.dart
@@ -53,10 +53,10 @@ class ApiDetailPage extends StatelessWidget {
             ],
             bottom: const TabBar(
               tabs: [
-                Tab(text: "API Details"),
-                Tab(text: "API Versions"),
-                Tab(text: "API Deployments"),
-                Tab(text: "API Artifacts"),
+                Tab(text: "Details"),
+                Tab(text: "Versions"),
+                Tab(text: "Deployments"),
+                Tab(text: "Artifacts"),
               ],
             ),
           ),

--- a/viewer/lib/pages/deployment_detail.dart
+++ b/viewer/lib/pages/deployment_detail.dart
@@ -54,8 +54,8 @@ class DeploymentDetailPage extends StatelessWidget {
             ],
             bottom: const TabBar(
               tabs: [
-                Tab(text: "Deployment Details"),
-                Tab(text: "Deployment Artifacts"),
+                Tab(text: "Details"),
+                Tab(text: "Artifacts"),
               ],
             ),
           ),

--- a/viewer/lib/pages/project_detail.dart
+++ b/viewer/lib/pages/project_detail.dart
@@ -53,9 +53,9 @@ class ProjectDetailPage extends StatelessWidget {
             ],
             bottom: const TabBar(
               tabs: [
-                Tab(text: "Project Details"),
+                Tab(text: "Details"),
                 Tab(text: "APIs"),
-                Tab(text: "Project Artifacts"),
+                Tab(text: "Artifacts"),
               ],
             ),
           ),

--- a/viewer/lib/pages/spec_detail.dart
+++ b/viewer/lib/pages/spec_detail.dart
@@ -55,9 +55,9 @@ class SpecDetailPage extends StatelessWidget {
             ],
             bottom: const TabBar(
               tabs: [
-                Tab(text: "Spec Details"),
-                Tab(text: "Spec Contents"),
-                Tab(text: "Spec Artifacts"),
+                Tab(text: "Details"),
+                Tab(text: "Contents"),
+                Tab(text: "Artifacts"),
               ],
             ),
           ),

--- a/viewer/lib/pages/version_detail.dart
+++ b/viewer/lib/pages/version_detail.dart
@@ -54,9 +54,9 @@ class VersionDetailPage extends StatelessWidget {
             ],
             bottom: const TabBar(
               tabs: [
-                Tab(text: "Version Details"),
-                Tab(text: "Version Specs"),
-                Tab(text: "Version Artifacts"),
+                Tab(text: "Details"),
+                Tab(text: "Specs"),
+                Tab(text: "Artifacts"),
               ],
             ),
           ),


### PR DESCRIPTION
This reduces text in tabs to single words so that text isn't truncated on narrow displays (e.g. phone screens).