### PR TITLE
Order display of projects and apis by their display names.

### DIFF
--- a/viewer/lib/service/service.dart
+++ b/viewer/lib/service/service.dart
@@ -61,6 +61,7 @@ class ProjectService {
     final client = getAdminClient()!;
     final request = ListProjectsRequest();
     request.pageSize = limit;
+    request.orderBy = "display_name";
 
     if (filter != null) {
       request.filter = filter!;
@@ -120,6 +121,7 @@ class ApiService {
     final request = ListApisRequest();
     request.parent = parent + "/locations/global";
     request.pageSize = limit;
+    request.orderBy = "display_name";
     if (filter != null) {
       request.filter = filter!;
     }


### PR DESCRIPTION
Now that the API supports it, we can make this nice upgrade. Previously, results were ordered by id, which didn't always sort in the same order as display names. This only applies to projects and apis because versions, specs, and deployments rarely have inconsistency between their ids and display names, although we might revisit this if needed.

![image](https://user-images.githubusercontent.com/405/214416706-566adbe9-dce9-45fa-8da5-21365dd797ae.png)
