### PR TITLE
Clear selections when filters change

### DIFF
--- a/viewer/lib/components/api_list.dart
+++ b/viewer/lib/components/api_list.dart
@@ -100,6 +100,7 @@ class _ApiListViewState extends State<ApiListView> {
         widget.pageLoadController!.reset();
         selectedIndex = -1;
       }
+      SelectionProvider.of(context)?.updateApiName("");
     });
   }
 

--- a/viewer/lib/components/artifact_list.dart
+++ b/viewer/lib/components/artifact_list.dart
@@ -148,6 +148,7 @@ class _ArtifactListViewState extends State<ArtifactListView> {
         widget.pageLoadController!.reset();
         selectedIndex = -1;
       }
+      SelectionProvider.of(context)?.updateArtifactName("");
     });
   }
 

--- a/viewer/lib/components/deployment_list.dart
+++ b/viewer/lib/components/deployment_list.dart
@@ -102,6 +102,7 @@ class _DeploymentListViewState extends State<DeploymentListView> {
         widget.pageLoadController!.reset();
         selectedIndex = -1;
       }
+      SelectionProvider.of(context)?.updateDeploymentName("");
     });
   }
 

--- a/viewer/lib/components/spec_list.dart
+++ b/viewer/lib/components/spec_list.dart
@@ -100,6 +100,7 @@ class _SpecListViewState extends State<SpecListView> {
         widget.pageLoadController!.reset();
         selectedIndex = -1;
       }
+      SelectionProvider.of(context)?.updateSpecName("");
     });
   }
 

--- a/viewer/lib/components/version_list.dart
+++ b/viewer/lib/components/version_list.dart
@@ -102,6 +102,7 @@ class _VersionListViewState extends State<VersionListView> {
         widget.pageLoadController!.reset();
         selectedIndex = -1;
       }
+      SelectionProvider.of(context)?.updateVersionName("");
     });
   }
 


### PR DESCRIPTION
This clears the selection that controls what is displayed in detail views whenever the filter value changes. Prior to this change, we could change the filter so that nothing matched and the detail view would continue to show results from the previous listing.