### PR TITLE
Standardize "empty" detail views and simplify build functions.

### DIFF
--- a/viewer/lib/components/api_detail.dart
+++ b/viewer/lib/components/api_detail.dart
@@ -17,6 +17,7 @@ import 'package:registry/registry.dart';
 import '../components/api_edit.dart';
 import '../components/detail_rows.dart';
 import '../components/dialog_builder.dart';
+import '../components/empty.dart';
 import '../models/api.dart';
 import '../models/selection.dart';
 import '../service/registry.dart';
@@ -73,6 +74,9 @@ class _ApiDetailCardState extends State<ApiDetailCard> {
 
   @override
   Widget build(BuildContext context) {
+    if (apiManager?.value == null) {
+      return emptyCard(context, "api");
+    }
     Function? selflink = onlyIf(widget.selflink, () {
       Api api = (apiManager?.value)!;
       Navigator.pushNamed(
@@ -95,60 +99,55 @@ class _ApiDetailCardState extends State<ApiDetailCard> {
             );
           });
     });
-
-    if (apiManager?.value == null) {
-      return Card();
-    } else {
-      final api = apiManager!.value!;
-      return Card(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            ResourceNameButtonRow(
-              name: api.name.split("/").sublist(2).join("/"),
-              show: selflink as void Function()?,
-              edit: editable as void Function()?,
-            ),
-            Expanded(
-              child: Padding(
-                padding: EdgeInsets.fromLTRB(16, 0, 16, 0),
-                child: SingleChildScrollView(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
+    final api = apiManager!.value!;
+    return Card(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ResourceNameButtonRow(
+            name: api.name.split("/").sublist(2).join("/"),
+            show: selflink as void Function()?,
+            edit: editable as void Function()?,
+          ),
+          Expanded(
+            child: Padding(
+              padding: EdgeInsets.fromLTRB(16, 0, 16, 0),
+              child: SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    PageSection(children: [
+                      TitleRow(api.displayName, action: selflink),
+                    ]),
+                    PageSection(
+                      children: [
+                        BodyRow(
+                          api.description,
+                          style: Theme.of(context).textTheme.bodyText2,
+                          wrap: true,
+                        ),
+                      ],
+                    ),
+                    PageSection(
+                      children: [
+                        TimestampRow(api.createTime, api.updateTime),
+                      ],
+                    ),
+                    if (api.labels.length > 0)
                       PageSection(children: [
-                        TitleRow(api.displayName, action: selflink),
+                        LabelsRow(api.labels),
                       ]),
-                      PageSection(
-                        children: [
-                          BodyRow(
-                            api.description,
-                            style: Theme.of(context).textTheme.bodyText2,
-                            wrap: true,
-                          ),
-                        ],
-                      ),
-                      PageSection(
-                        children: [
-                          TimestampRow(api.createTime, api.updateTime),
-                        ],
-                      ),
-                      if (api.labels.length > 0)
-                        PageSection(children: [
-                          LabelsRow(api.labels),
-                        ]),
-                      if (api.annotations.length > 0)
-                        PageSection(children: [
-                          AnnotationsRow(api.annotations),
-                        ]),
-                    ],
-                  ),
+                    if (api.annotations.length > 0)
+                      PageSection(children: [
+                        AnnotationsRow(api.annotations),
+                      ]),
+                  ],
                 ),
               ),
             ),
-          ],
-        ),
-      );
-    }
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/viewer/lib/components/artifact_detail.dart
+++ b/viewer/lib/components/artifact_detail.dart
@@ -22,6 +22,7 @@ import 'artifact_detail_lintstats.dart';
 import 'artifact_detail_references.dart';
 import 'artifact_detail_string.dart';
 import 'artifact_detail_vocabulary.dart';
+import '../components/empty.dart';
 import '../helpers/extensions.dart';
 import '../models/artifact.dart';
 import '../models/selection.dart';
@@ -79,6 +80,9 @@ class _ArtifactDetailCardState extends State<ArtifactDetailCard> {
 
   @override
   Widget build(BuildContext context) {
+    if (artifactManager?.value == null) {
+      return emptyCard(context, "artifact");
+    }
     Function? selflink = onlyIf(widget.selflink, () {
       Artifact artifact = (artifactManager?.value)!;
       Navigator.pushNamed(
@@ -87,93 +91,84 @@ class _ArtifactDetailCardState extends State<ArtifactDetailCard> {
       );
     });
 
-    if (artifactManager?.value == null) {
-      return Card(
-        child: Container(
-          color: Theme.of(context).canvasColor,
-        ),
-      );
-    } else {
-      Artifact artifact = artifactManager!.value!;
-      if (artifact.mimeType.startsWith("application/yaml") ||
-          artifact.mimeType.startsWith("application/json")) {
-        return StringArtifactCard(artifact,
-            selflink: selflink, editable: false);
-      }
-      switch (artifact.mimeType) {
-        case "text/plain":
-          return StringArtifactCard(
-            artifact,
-            selflink: selflink,
-            editable: widget.editable,
-          );
-        case "application/octet-stream;type=gnostic.metrics.Complexity":
-          return ComplexityArtifactCard(artifact, selflink: selflink);
-        case "application/octet-stream;type=gnostic.metrics.Vocabulary":
-          return VocabularyArtifactCard(artifact, selflink: selflink);
-        case "application/octet-stream;type=google.cloud.apigeeregistry.v1.apihub.ApiSpecExtensionList":
-          return MessageArtifactCard(
-              artifact, new ApiSpecExtensionList.fromBuffer(artifact.contents),
-              selflink: selflink);
-        case "application/octet-stream;type=google.cloud.apigeeregistry.v1.apihub.DisplaySettings":
-          return MessageArtifactCard(
-              artifact, new DisplaySettings.fromBuffer(artifact.contents),
-              selflink: selflink);
-        case "application/octet-stream;type=google.cloud.apigeeregistry.v1.apihub.Lifecycle":
-          return MessageArtifactCard(
-              artifact, new Lifecycle.fromBuffer(artifact.contents),
-              selflink: selflink);
-        case "application/octet-stream;type=google.cloud.apigeeregistry.v1.apihub.ReferenceList":
-          return MessageArtifactCard(
-              artifact, new ReferenceList.fromBuffer(artifact.contents),
-              selflink: selflink);
-        case "application/octet-stream;type=google.cloud.apigeeregistry.v1.apihub.TaxonomyList":
-          return MessageArtifactCard(
-              artifact, new TaxonomyList.fromBuffer(artifact.contents),
-              selflink: selflink);
-        case "application/octet-stream;type=google.cloud.apigeeregistry.v1.controller.Manifest":
-          return MessageArtifactCard(
-              artifact, new Manifest.fromBuffer(artifact.contents),
-              selflink: selflink);
-        case "application/octet-stream;type=google.cloud.apigeeregistry.v1.controller.Receipt":
-          return MessageArtifactCard(
-              artifact, new Receipt.fromBuffer(artifact.contents),
-              selflink: selflink);
-        case "application/octet-stream;type=google.cloud.apigeeregistry.v1.scoring.Score":
-          return MessageArtifactCard(
-              artifact, new Score.fromBuffer(artifact.contents),
-              selflink: selflink);
-        case "application/octet-stream;type=google.cloud.apigeeregistry.v1.scoring.ScoreCard":
-          return MessageArtifactCard(
-              artifact, new ScoreCard.fromBuffer(artifact.contents),
-              selflink: selflink);
-        case "application/octet-stream;type=google.cloud.apigeeregistry.v1.scoring.ScoreCardDefinition":
-          return MessageArtifactCard(
-              artifact, new ScoreCardDefinition.fromBuffer(artifact.contents),
-              selflink: selflink);
-        case "application/octet-stream;type=google.cloud.apigeeregistry.v1.scoring.ScoreDefinition":
-          return MessageArtifactCard(
-              artifact, new ScoreDefinition.fromBuffer(artifact.contents),
-              selflink: selflink);
-        case "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.ConformanceReport":
-          return MessageArtifactCard(
-              artifact, new ConformanceReport.fromBuffer(artifact.contents),
-              selflink: selflink);
-        case "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.StyleGuide":
-          return MessageArtifactCard(
-              artifact, new StyleGuide.fromBuffer(artifact.contents),
-              selflink: selflink);
-        case "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.Lint":
-          return LintArtifactCard(artifact, selflink: selflink);
-        case "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.LintStats":
-          return LintStatsArtifactCard(artifact, selflink: selflink);
-        case "application/octet-stream;type=google.cloud.apigeeregistry.v1.apihub.References":
-          return ReferencesArtifactCard(artifact, selflink: selflink);
-      }
-
-      // otherwise return a default display of the artifact
-      return DefaultArtifactDetailCard(selflink: selflink);
+    Artifact artifact = artifactManager!.value!;
+    if (artifact.mimeType.startsWith("application/yaml") ||
+        artifact.mimeType.startsWith("application/json")) {
+      return StringArtifactCard(artifact, selflink: selflink, editable: false);
     }
+    switch (artifact.mimeType) {
+      case "text/plain":
+        return StringArtifactCard(
+          artifact,
+          selflink: selflink,
+          editable: widget.editable,
+        );
+      case "application/octet-stream;type=gnostic.metrics.Complexity":
+        return ComplexityArtifactCard(artifact, selflink: selflink);
+      case "application/octet-stream;type=gnostic.metrics.Vocabulary":
+        return VocabularyArtifactCard(artifact, selflink: selflink);
+      case "application/octet-stream;type=google.cloud.apigeeregistry.v1.apihub.ApiSpecExtensionList":
+        return MessageArtifactCard(
+            artifact, new ApiSpecExtensionList.fromBuffer(artifact.contents),
+            selflink: selflink);
+      case "application/octet-stream;type=google.cloud.apigeeregistry.v1.apihub.DisplaySettings":
+        return MessageArtifactCard(
+            artifact, new DisplaySettings.fromBuffer(artifact.contents),
+            selflink: selflink);
+      case "application/octet-stream;type=google.cloud.apigeeregistry.v1.apihub.Lifecycle":
+        return MessageArtifactCard(
+            artifact, new Lifecycle.fromBuffer(artifact.contents),
+            selflink: selflink);
+      case "application/octet-stream;type=google.cloud.apigeeregistry.v1.apihub.ReferenceList":
+        return MessageArtifactCard(
+            artifact, new ReferenceList.fromBuffer(artifact.contents),
+            selflink: selflink);
+      case "application/octet-stream;type=google.cloud.apigeeregistry.v1.apihub.TaxonomyList":
+        return MessageArtifactCard(
+            artifact, new TaxonomyList.fromBuffer(artifact.contents),
+            selflink: selflink);
+      case "application/octet-stream;type=google.cloud.apigeeregistry.v1.controller.Manifest":
+        return MessageArtifactCard(
+            artifact, new Manifest.fromBuffer(artifact.contents),
+            selflink: selflink);
+      case "application/octet-stream;type=google.cloud.apigeeregistry.v1.controller.Receipt":
+        return MessageArtifactCard(
+            artifact, new Receipt.fromBuffer(artifact.contents),
+            selflink: selflink);
+      case "application/octet-stream;type=google.cloud.apigeeregistry.v1.scoring.Score":
+        return MessageArtifactCard(
+            artifact, new Score.fromBuffer(artifact.contents),
+            selflink: selflink);
+      case "application/octet-stream;type=google.cloud.apigeeregistry.v1.scoring.ScoreCard":
+        return MessageArtifactCard(
+            artifact, new ScoreCard.fromBuffer(artifact.contents),
+            selflink: selflink);
+      case "application/octet-stream;type=google.cloud.apigeeregistry.v1.scoring.ScoreCardDefinition":
+        return MessageArtifactCard(
+            artifact, new ScoreCardDefinition.fromBuffer(artifact.contents),
+            selflink: selflink);
+      case "application/octet-stream;type=google.cloud.apigeeregistry.v1.scoring.ScoreDefinition":
+        return MessageArtifactCard(
+            artifact, new ScoreDefinition.fromBuffer(artifact.contents),
+            selflink: selflink);
+      case "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.ConformanceReport":
+        return MessageArtifactCard(
+            artifact, new ConformanceReport.fromBuffer(artifact.contents),
+            selflink: selflink);
+      case "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.StyleGuide":
+        return MessageArtifactCard(
+            artifact, new StyleGuide.fromBuffer(artifact.contents),
+            selflink: selflink);
+      case "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.Lint":
+        return LintArtifactCard(artifact, selflink: selflink);
+      case "application/octet-stream;type=google.cloud.apigeeregistry.v1.style.LintStats":
+        return LintStatsArtifactCard(artifact, selflink: selflink);
+      case "application/octet-stream;type=google.cloud.apigeeregistry.v1.apihub.References":
+        return ReferencesArtifactCard(artifact, selflink: selflink);
+    }
+
+    // otherwise return a default display of the artifact
+    return DefaultArtifactDetailCard(selflink: selflink);
   }
 }
 

--- a/viewer/lib/components/deployment_detail.dart
+++ b/viewer/lib/components/deployment_detail.dart
@@ -17,6 +17,7 @@ import 'package:registry/registry.dart';
 import '../components/detail_rows.dart';
 import '../components/dialog_builder.dart';
 import '../components/deployment_edit.dart';
+import '../components/empty.dart';
 import '../models/selection.dart';
 import '../models/deployment.dart';
 import '../service/registry.dart';
@@ -90,6 +91,9 @@ class _DeploymentDetailCardState extends State<DeploymentDetailCard> {
 
   @override
   Widget build(BuildContext context) {
+    if (deploymentManager?.value == null) {
+      return emptyCard(context, "deployment");
+    }
     Function? selflink = onlyIf(widget.selflink, () {
       ApiDeployment deployment = (deploymentManager?.value)!;
       Navigator.pushNamed(
@@ -113,63 +117,59 @@ class _DeploymentDetailCardState extends State<DeploymentDetailCard> {
           });
     });
 
-    if (deploymentManager?.value == null) {
-      return Card();
-    } else {
-      Api? api = apiManager!.value;
-      ApiDeployment deployment = deploymentManager!.value!;
-      return Card(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            ResourceNameButtonRow(
-              name: deployment.name.split("/").sublist(4).join("/"),
-              show: selflink as void Function()?,
-              edit: editable as void Function()?,
-            ),
-            Expanded(
-              child: Padding(
-                padding: EdgeInsets.fromLTRB(16, 0, 16, 0),
-                child: SingleChildScrollView(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
+    Api? api = apiManager!.value;
+    ApiDeployment deployment = deploymentManager!.value!;
+    return Card(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ResourceNameButtonRow(
+            name: deployment.name.split("/").sublist(4).join("/"),
+            show: selflink as void Function()?,
+            edit: editable as void Function()?,
+          ),
+          Expanded(
+            child: Padding(
+              padding: EdgeInsets.fromLTRB(16, 0, 16, 0),
+              child: SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    PageSection(
+                      children: [
+                        SizedBox(height: 10),
+                        SuperTitleRow(api?.displayName ?? ""),
+                        TitleRow(deployment.name.split("/").last,
+                            action: selflink),
+                      ],
+                    ),
+                    if (deployment.description != "")
                       PageSection(
                         children: [
-                          SizedBox(height: 10),
-                          SuperTitleRow(api?.displayName ?? ""),
-                          TitleRow(deployment.name.split("/").last,
-                              action: selflink),
+                          BodyRow(deployment.description),
                         ],
                       ),
-                      if (deployment.description != "")
-                        PageSection(
-                          children: [
-                            BodyRow(deployment.description),
-                          ],
-                        ),
-                      PageSection(
-                        children: [
-                          TimestampRow(deployment.createTime,
-                              deployment.revisionUpdateTime),
-                        ],
-                      ),
-                      if (deployment.labels.length > 0)
-                        PageSection(children: [
-                          LabelsRow(deployment.labels),
-                        ]),
-                      if (deployment.annotations.length > 0)
-                        PageSection(children: [
-                          AnnotationsRow(deployment.annotations),
-                        ]),
-                    ],
-                  ),
+                    PageSection(
+                      children: [
+                        TimestampRow(deployment.createTime,
+                            deployment.revisionUpdateTime),
+                      ],
+                    ),
+                    if (deployment.labels.length > 0)
+                      PageSection(children: [
+                        LabelsRow(deployment.labels),
+                      ]),
+                    if (deployment.annotations.length > 0)
+                      PageSection(children: [
+                        AnnotationsRow(deployment.annotations),
+                      ]),
+                  ],
                 ),
               ),
             ),
-          ],
-        ),
-      );
-    }
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/viewer/lib/components/empty.dart
+++ b/viewer/lib/components/empty.dart
@@ -1,0 +1,24 @@
+// Copyright 2023 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:flutter/material.dart';
+
+Card emptyCard(BuildContext context, String kind) {
+  return Card(
+    child: Container(
+      child: Center(child: Text("no $kind selected")),
+      color: Theme.of(context).canvasColor,
+    ),
+  );
+}

--- a/viewer/lib/components/project_detail.dart
+++ b/viewer/lib/components/project_detail.dart
@@ -16,6 +16,7 @@ import 'package:flutter/material.dart';
 import 'package:registry/registry.dart';
 import '../components/detail_rows.dart';
 import '../components/dialog_builder.dart';
+import '../components/empty.dart';
 import '../components/project_edit.dart';
 import '../models/project.dart';
 import '../models/selection.dart';
@@ -73,6 +74,9 @@ class _ProjectDetailCardState extends State<ProjectDetailCard> {
 
   @override
   Widget build(BuildContext context) {
+    if (projectManager?.value == null) {
+      return emptyCard(context, "project");
+    }
     Function? selflink = onlyIf(widget.selflink, () {
       Project project = (projectManager?.value)!;
       Navigator.pushNamed(
@@ -97,40 +101,36 @@ class _ProjectDetailCardState extends State<ProjectDetailCard> {
           });
     });
 
-    if (projectManager?.value == null) {
-      return Card();
-    } else {
-      Project project = projectManager!.value!;
-      return Card(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            ResourceNameButtonRow(
-              name: project.name,
-              show: selflink as void Function()?,
-              edit: editable as void Function()?,
-            ),
-            Expanded(
-              child: Padding(
-                padding: EdgeInsets.fromLTRB(16, 0, 16, 0),
-                child: SingleChildScrollView(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      SizedBox(height: 10),
-                      TitleRow(project.displayName, action: selflink),
-                      SizedBox(height: 10),
-                      BodyRow(project.description),
-                      SizedBox(height: 10),
-                      TimestampRow(project.createTime, project.updateTime),
-                    ],
-                  ),
+    Project project = projectManager!.value!;
+    return Card(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ResourceNameButtonRow(
+            name: project.name,
+            show: selflink as void Function()?,
+            edit: editable as void Function()?,
+          ),
+          Expanded(
+            child: Padding(
+              padding: EdgeInsets.fromLTRB(16, 0, 16, 0),
+              child: SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    SizedBox(height: 10),
+                    TitleRow(project.displayName, action: selflink),
+                    SizedBox(height: 10),
+                    BodyRow(project.description),
+                    SizedBox(height: 10),
+                    TimestampRow(project.createTime, project.updateTime),
+                  ],
                 ),
               ),
             ),
-          ],
-        ),
-      );
-    }
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/viewer/lib/components/spec_detail.dart
+++ b/viewer/lib/components/spec_detail.dart
@@ -18,6 +18,7 @@ import 'package:google_fonts/google_fonts.dart';
 import '../components/detail_rows.dart';
 import '../components/dialog_builder.dart';
 import '../components/spec_edit.dart';
+import '../components/empty.dart';
 import '../helpers/extensions.dart';
 import '../models/selection.dart';
 import '../models/spec.dart';
@@ -108,6 +109,9 @@ class _SpecDetailCardState extends State<SpecDetailCard> {
 
   @override
   Widget build(BuildContext context) {
+    if (specManager?.value == null) {
+      return emptyCard(context, "spec");
+    }
     Function? selflink = onlyIf(widget.selflink, () {
       ApiSpec spec = (specManager?.value)!;
       Navigator.pushNamed(
@@ -131,79 +135,74 @@ class _SpecDetailCardState extends State<SpecDetailCard> {
           });
     });
 
-    if (specManager?.value == null) {
+    Api? api = apiManager!.value;
+    ApiVersion? version = versionManager!.value;
+    ApiSpec? spec = specManager!.value;
+    if ((api == null) || (version == null) || (spec == null)) {
       return Card();
-    } else {
-      Api? api = apiManager!.value;
-      ApiVersion? version = versionManager!.value;
-      ApiSpec? spec = specManager!.value;
-      if ((api == null) || (version == null) || (spec == null)) {
-        return Card();
-      }
-      final codeStyle = GoogleFonts.inconsolata();
-      return Card(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            ResourceNameButtonRow(
-              name: spec.name.last(1),
-              show: selflink as void Function()?,
-              edit: editable as void Function()?,
-            ),
-            Expanded(
-              child: Padding(
-                padding: EdgeInsets.fromLTRB(16, 0, 16, 0),
-                child: SingleChildScrollView(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
+    }
+    final codeStyle = GoogleFonts.inconsolata();
+    return Card(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ResourceNameButtonRow(
+            name: spec.name.last(1),
+            show: selflink as void Function()?,
+            edit: editable as void Function()?,
+          ),
+          Expanded(
+            child: Padding(
+              padding: EdgeInsets.fromLTRB(16, 0, 16, 0),
+              child: SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    PageSection(
+                      children: [
+                        SuperTitleRow(api.displayName +
+                            "/" +
+                            version.name.split("/").last),
+                        TitleRow(spec.name.split("/").last, action: selflink),
+                      ],
+                    ),
+                    if (spec.hasSourceUri())
                       PageSection(
                         children: [
-                          SuperTitleRow(api.displayName +
-                              "/" +
-                              version.name.split("/").last),
-                          TitleRow(spec.name.split("/").last, action: selflink),
+                          LinkRow("${spec.sourceUri}", spec.sourceUri),
                         ],
                       ),
-                      if (spec.hasSourceUri())
-                        PageSection(
-                          children: [
-                            LinkRow("${spec.sourceUri}", spec.sourceUri),
-                          ],
-                        ),
+                    PageSection(
+                      children: [
+                        BodyRow(spec.mimeType, style: codeStyle),
+                        BodyRow("revision " + spec.revisionId,
+                            style: codeStyle),
+                        BodyRow("${spec.sizeBytes} bytes", style: codeStyle),
+                        BodyRow("SHA-256 ${spec.hash}", style: codeStyle),
+                        TimestampRow(spec.createTime, spec.revisionUpdateTime),
+                      ],
+                    ),
+                    if (spec.description != "")
                       PageSection(
                         children: [
-                          BodyRow(spec.mimeType, style: codeStyle),
-                          BodyRow("revision " + spec.revisionId,
-                              style: codeStyle),
-                          BodyRow("${spec.sizeBytes} bytes", style: codeStyle),
-                          BodyRow("SHA-256 ${spec.hash}", style: codeStyle),
-                          TimestampRow(
-                              spec.createTime, spec.revisionUpdateTime),
+                          BodyRow(spec.description),
                         ],
                       ),
-                      if (spec.description != "")
-                        PageSection(
-                          children: [
-                            BodyRow(spec.description),
-                          ],
-                        ),
-                      if (spec.labels.length > 0)
-                        PageSection(children: [
-                          LabelsRow(spec.labels),
-                        ]),
-                      if (spec.annotations.length > 0)
-                        PageSection(children: [
-                          AnnotationsRow(spec.annotations),
-                        ]),
-                    ],
-                  ),
+                    if (spec.labels.length > 0)
+                      PageSection(children: [
+                        LabelsRow(spec.labels),
+                      ]),
+                    if (spec.annotations.length > 0)
+                      PageSection(children: [
+                        AnnotationsRow(spec.annotations),
+                      ]),
+                  ],
                 ),
               ),
             ),
-          ],
-        ),
-      );
-    }
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/viewer/lib/components/version_detail.dart
+++ b/viewer/lib/components/version_detail.dart
@@ -16,6 +16,7 @@ import 'package:flutter/material.dart';
 import 'package:registry/registry.dart';
 import '../components/detail_rows.dart';
 import '../components/dialog_builder.dart';
+import '../components/empty.dart';
 import '../components/version_edit.dart';
 import '../models/selection.dart';
 import '../models/version.dart';
@@ -89,6 +90,10 @@ class _VersionDetailCardState extends State<VersionDetailCard> {
 
   @override
   Widget build(BuildContext context) {
+    if (versionManager?.value == null) {
+      return emptyCard(context, "version");
+    }
+
     Function? selflink = onlyIf(widget.selflink, () {
       ApiVersion version = (versionManager?.value)!;
       Navigator.pushNamed(
@@ -112,62 +117,58 @@ class _VersionDetailCardState extends State<VersionDetailCard> {
           });
     });
 
-    if (versionManager?.value == null) {
-      return Card();
-    } else {
-      Api? api = apiManager!.value;
-      ApiVersion version = versionManager!.value!;
-      return Card(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            ResourceNameButtonRow(
-              name: version.name.split("/").sublist(4).join("/"),
-              show: selflink as void Function()?,
-              edit: editable as void Function()?,
-            ),
-            Expanded(
-              child: Padding(
-                padding: EdgeInsets.fromLTRB(16, 0, 16, 0),
-                child: SingleChildScrollView(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
+    Api? api = apiManager!.value;
+    ApiVersion version = versionManager!.value!;
+    return Card(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ResourceNameButtonRow(
+            name: version.name.split("/").sublist(4).join("/"),
+            show: selflink as void Function()?,
+            edit: editable as void Function()?,
+          ),
+          Expanded(
+            child: Padding(
+              padding: EdgeInsets.fromLTRB(16, 0, 16, 0),
+              child: SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    PageSection(
+                      children: [
+                        SizedBox(height: 10),
+                        SuperTitleRow(api?.displayName ?? ""),
+                        TitleRow(version.name.split("/").last,
+                            action: selflink),
+                      ],
+                    ),
+                    if (version.description != "")
                       PageSection(
                         children: [
-                          SizedBox(height: 10),
-                          SuperTitleRow(api?.displayName ?? ""),
-                          TitleRow(version.name.split("/").last,
-                              action: selflink),
+                          BodyRow(version.description),
                         ],
                       ),
-                      if (version.description != "")
-                        PageSection(
-                          children: [
-                            BodyRow(version.description),
-                          ],
-                        ),
-                      PageSection(
-                        children: [
-                          TimestampRow(version.createTime, version.updateTime),
-                        ],
-                      ),
-                      if (version.labels.length > 0)
-                        PageSection(children: [
-                          LabelsRow(version.labels),
-                        ]),
-                      if (version.annotations.length > 0)
-                        PageSection(children: [
-                          AnnotationsRow(version.annotations),
-                        ]),
-                    ],
-                  ),
+                    PageSection(
+                      children: [
+                        TimestampRow(version.createTime, version.updateTime),
+                      ],
+                    ),
+                    if (version.labels.length > 0)
+                      PageSection(children: [
+                        LabelsRow(version.labels),
+                      ]),
+                    if (version.annotations.length > 0)
+                      PageSection(children: [
+                        AnnotationsRow(version.annotations),
+                      ]),
+                  ],
                 ),
               ),
             ),
-          ],
-        ),
-      );
-    }
+          ),
+        ],
+      ),
+    );
   }
 }


### PR DESCRIPTION
This uses a new common "empty" view for detail views without contents (because no selection is made). In a related change, the test for emptiness is made at the start of `build` methods to simplify their overall flow (most of the diffs are from indentation changes caused by this).