### PR TITLE
Set page titles for detail pages to the corresponding resource names.

### DIFF
--- a/viewer/lib/helpers/title.dart
+++ b/viewer/lib/helpers/title.dart
@@ -16,10 +16,23 @@ const pathLength = 3;
 
 // title converts a path into a string suitable for display in the app bar.
 String title(String path) {
+  path = path.replaceAll("/locations/global", "");
+
   var parts = path.split("/").sublist(1);
   if (parts.length > pathLength) {
     parts = parts.sublist(parts.length - pathLength);
     parts.insert(0, "...");
   }
   return parts.join("/");
+}
+
+String? pageTitle(String? path) {
+  if (path == null) {
+    return null;
+  }
+  if (path[0] == '/') {
+    path = path.substring(1);
+  }
+  path = path.replaceAll("/locations/global", "");
+  return path;
 }

--- a/viewer/lib/pages/api_detail.dart
+++ b/viewer/lib/pages/api_detail.dart
@@ -25,6 +25,7 @@ import '../components/artifact_detail.dart';
 import '../components/bottom_bar.dart';
 import '../components/home_button.dart';
 import '../components/split_view.dart';
+import '../helpers/title.dart';
 
 class ApiDetailPage extends StatelessWidget {
   final String? name;
@@ -47,7 +48,7 @@ class ApiDetailPage extends StatelessWidget {
           appBar: AppBar(
             centerTitle: true,
             title: Text(
-              this.name ?? "API Details",
+              pageTitle(this.name) ?? "API Details",
             ),
             actions: <Widget>[
               homeButton(context),

--- a/viewer/lib/pages/deployment_detail.dart
+++ b/viewer/lib/pages/deployment_detail.dart
@@ -23,6 +23,7 @@ import '../components/artifact_detail.dart';
 import '../components/bottom_bar.dart';
 import '../components/home_button.dart';
 import '../components/split_view.dart';
+import '../helpers/title.dart';
 
 class DeploymentDetailPage extends StatelessWidget {
   final String? name;
@@ -48,7 +49,7 @@ class DeploymentDetailPage extends StatelessWidget {
           appBar: AppBar(
             centerTitle: true,
             title: Text(
-              this.name ?? "Deployment Details",
+              pageTitle(this.name) ?? "Deployment Details",
             ),
             actions: <Widget>[
               homeButton(context),

--- a/viewer/lib/pages/project_detail.dart
+++ b/viewer/lib/pages/project_detail.dart
@@ -24,6 +24,7 @@ import '../components/bottom_bar.dart';
 import '../components/home_button.dart';
 import '../components/split_view.dart';
 import '../helpers/root.dart';
+import '../helpers/title.dart';
 
 class ProjectDetailPage extends StatelessWidget {
   final String? name;
@@ -47,7 +48,7 @@ class ProjectDetailPage extends StatelessWidget {
           appBar: AppBar(
             centerTitle: true,
             title: Text(
-              this.name ?? "Project Details",
+              pageTitle(this.name) ?? "Project Details",
             ),
             actions: <Widget>[
               homeButton(context),

--- a/viewer/lib/pages/spec_detail.dart
+++ b/viewer/lib/pages/spec_detail.dart
@@ -22,6 +22,7 @@ import '../components/artifact_detail.dart';
 import '../components/bottom_bar.dart';
 import '../components/home_button.dart';
 import '../components/split_view.dart';
+import '../helpers/title.dart';
 
 class SpecDetailPage extends StatelessWidget {
   final String? name;
@@ -49,7 +50,7 @@ class SpecDetailPage extends StatelessWidget {
           appBar: AppBar(
             centerTitle: true,
             title: Text(
-              this.name ?? "Spec Details",
+              pageTitle(this.name) ?? "Spec Details",
             ),
             actions: <Widget>[
               homeButton(context),

--- a/viewer/lib/pages/version_detail.dart
+++ b/viewer/lib/pages/version_detail.dart
@@ -23,6 +23,7 @@ import '../components/artifact_detail.dart';
 import '../components/bottom_bar.dart';
 import '../components/home_button.dart';
 import '../components/split_view.dart';
+import '../helpers/title.dart';
 
 class VersionDetailPage extends StatelessWidget {
   final String? name;
@@ -48,7 +49,7 @@ class VersionDetailPage extends StatelessWidget {
           appBar: AppBar(
             centerTitle: true,
             title: Text(
-              this.name ?? "Version Details",
+              pageTitle(this.name) ?? "Version Details",
             ),
             actions: <Widget>[
               homeButton(context),


### PR DESCRIPTION
This changes the title at the top of the page from "API Details", etc. to the resource names of the entities being described.

![image](https://user-images.githubusercontent.com/405/214463001-f200b899-96b0-4cbd-bfee-047ffeaf3658.png)

(screenshot for previous PRs included this unmerged change)