### PR TITLE
Tweak tab bar style to make the selected tab easier to see.

### DIFF
--- a/viewer/lib/helpers/tab_decoration.dart
+++ b/viewer/lib/helpers/tab_decoration.dart
@@ -1,0 +1,24 @@
+// Copyright 2023 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import 'package:flutter/material.dart';
+
+const Radius radius = Radius.circular(0);
+
+Decoration tabDecoration(BuildContext context) {
+  return ShapeDecoration(
+    shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.only(topRight: radius, topLeft: radius)),
+    color: Theme.of(context).toggleableActiveColor,
+  );
+}

--- a/viewer/lib/pages/api_detail.dart
+++ b/viewer/lib/pages/api_detail.dart
@@ -25,6 +25,7 @@ import '../components/artifact_detail.dart';
 import '../components/bottom_bar.dart';
 import '../components/home_button.dart';
 import '../components/split_view.dart';
+import '../helpers/tab_decoration.dart';
 import '../helpers/title.dart';
 
 class ApiDetailPage extends StatelessWidget {
@@ -53,13 +54,14 @@ class ApiDetailPage extends StatelessWidget {
             actions: <Widget>[
               homeButton(context),
             ],
-            bottom: const TabBar(
+            bottom: TabBar(
               tabs: [
                 Tab(text: "Details"),
                 Tab(text: "Versions"),
                 Tab(text: "Deployments"),
                 Tab(text: "Artifacts"),
               ],
+              indicator: tabDecoration(context),
             ),
           ),
           body: Column(

--- a/viewer/lib/pages/deployment_detail.dart
+++ b/viewer/lib/pages/deployment_detail.dart
@@ -23,6 +23,7 @@ import '../components/artifact_detail.dart';
 import '../components/bottom_bar.dart';
 import '../components/home_button.dart';
 import '../components/split_view.dart';
+import '../helpers/tab_decoration.dart';
 import '../helpers/title.dart';
 
 class DeploymentDetailPage extends StatelessWidget {
@@ -54,11 +55,12 @@ class DeploymentDetailPage extends StatelessWidget {
             actions: <Widget>[
               homeButton(context),
             ],
-            bottom: const TabBar(
+            bottom: TabBar(
               tabs: [
                 Tab(text: "Details"),
                 Tab(text: "Artifacts"),
               ],
+              indicator: tabDecoration(context),
             ),
           ),
           body: Column(

--- a/viewer/lib/pages/project_detail.dart
+++ b/viewer/lib/pages/project_detail.dart
@@ -24,6 +24,7 @@ import '../components/bottom_bar.dart';
 import '../components/home_button.dart';
 import '../components/split_view.dart';
 import '../helpers/root.dart';
+import '../helpers/tab_decoration.dart';
 import '../helpers/title.dart';
 
 class ProjectDetailPage extends StatelessWidget {
@@ -53,12 +54,13 @@ class ProjectDetailPage extends StatelessWidget {
             actions: <Widget>[
               homeButton(context),
             ],
-            bottom: const TabBar(
+            bottom: TabBar(
               tabs: [
                 Tab(text: "Details"),
                 Tab(text: "APIs"),
                 Tab(text: "Artifacts"),
               ],
+              indicator: tabDecoration(context),
             ),
           ),
           body: Column(

--- a/viewer/lib/pages/spec_detail.dart
+++ b/viewer/lib/pages/spec_detail.dart
@@ -22,6 +22,7 @@ import '../components/artifact_detail.dart';
 import '../components/bottom_bar.dart';
 import '../components/home_button.dart';
 import '../components/split_view.dart';
+import '../helpers/tab_decoration.dart';
 import '../helpers/title.dart';
 
 class SpecDetailPage extends StatelessWidget {
@@ -55,12 +56,13 @@ class SpecDetailPage extends StatelessWidget {
             actions: <Widget>[
               homeButton(context),
             ],
-            bottom: const TabBar(
+            bottom: TabBar(
               tabs: [
                 Tab(text: "Details"),
                 Tab(text: "Contents"),
                 Tab(text: "Artifacts"),
               ],
+              indicator: tabDecoration(context),
             ),
           ),
           body: Column(children: [

--- a/viewer/lib/pages/version_detail.dart
+++ b/viewer/lib/pages/version_detail.dart
@@ -23,6 +23,7 @@ import '../components/artifact_detail.dart';
 import '../components/bottom_bar.dart';
 import '../components/home_button.dart';
 import '../components/split_view.dart';
+import '../helpers/tab_decoration.dart';
 import '../helpers/title.dart';
 
 class VersionDetailPage extends StatelessWidget {
@@ -54,12 +55,13 @@ class VersionDetailPage extends StatelessWidget {
             actions: <Widget>[
               homeButton(context),
             ],
-            bottom: const TabBar(
+            bottom: TabBar(
               tabs: [
                 Tab(text: "Details"),
                 Tab(text: "Specs"),
                 Tab(text: "Artifacts"),
               ],
+              indicator: tabDecoration(context),
             ),
           ),
           body: Column(


### PR DESCRIPTION
This is a small cosmetic customization that makes it easier to see which tab is selected.

Here is a view without the change:
![image](https://user-images.githubusercontent.com/405/214472198-51167713-253c-45ca-8e38-1093fe00db10.png)

Here is a view with the change (note that in both, the leftmost tab is selected):
![image](https://user-images.githubusercontent.com/405/214472288-0a3d14ab-2e53-4a70-b7f9-5c9b53edb4a9.png)
