### PR TITLE
Use a simple "media query" to adjust content for narrow screens.

### DIFF
--- a/viewer/lib/components/home.dart
+++ b/viewer/lib/components/home.dart
@@ -20,6 +20,7 @@ import '../components/registry_detail.dart';
 import '../models/selection.dart';
 import '../components/bottom_bar.dart';
 import '../components/split_view.dart';
+import '../helpers/media.dart';
 
 class Home extends StatelessWidget {
   @override
@@ -31,12 +32,14 @@ class Home extends StatelessWidget {
         child: Column(
           children: [
             Expanded(
-              child: CustomSplitView(
-                viewMode: SplitViewMode.Horizontal,
-                initialWeight: 0.33,
-                view1: ProjectListCard(),
-                view2: ProjectDetailCard(selflink: true, editable: true),
-              ),
+              child: narrow(context)
+                  ? ProjectListCard()
+                  : CustomSplitView(
+                      viewMode: SplitViewMode.Horizontal,
+                      initialWeight: 0.33,
+                      view1: ProjectListCard(),
+                      view2: ProjectDetailCard(selflink: true, editable: true),
+                    ),
             ),
             BottomBar(),
           ],

--- a/viewer/lib/helpers/media.dart
+++ b/viewer/lib/helpers/media.dart
@@ -1,0 +1,19 @@
+// Copyright 2023 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import 'package:flutter/material.dart';
+
+bool narrow(BuildContext context) {
+  MediaQueryData media = MediaQuery.of(context);
+  return media.size.width <= 800;
+}

--- a/viewer/lib/pages/api_detail.dart
+++ b/viewer/lib/pages/api_detail.dart
@@ -25,6 +25,7 @@ import '../components/artifact_detail.dart';
 import '../components/bottom_bar.dart';
 import '../components/home_button.dart';
 import '../components/split_view.dart';
+import '../helpers/media.dart';
 import '../helpers/tab_decoration.dart';
 import '../helpers/title.dart';
 
@@ -70,32 +71,38 @@ class ApiDetailPage extends StatelessWidget {
                 child: TabBarView(
                   children: [
                     ApiDetailCard(editable: true),
-                    CustomSplitView(
-                      viewMode: SplitViewMode.Horizontal,
-                      initialWeight: 0.33,
-                      view1: VersionListCard(),
-                      view2: VersionDetailCard(
-                        selflink: true,
-                        editable: true,
-                      ),
-                    ),
-                    CustomSplitView(
-                      viewMode: SplitViewMode.Horizontal,
-                      initialWeight: 0.33,
-                      view1: DeploymentListCard(),
-                      view2: DeploymentDetailCard(
-                        selflink: true,
-                        editable: true,
-                      ),
-                    ),
-                    CustomSplitView(
-                      viewMode: SplitViewMode.Horizontal,
-                      view1: ArtifactListCard(SelectionProvider.api),
-                      view2: ArtifactDetailCard(
-                        selflink: true,
-                        editable: true,
-                      ),
-                    ),
+                    narrow(context)
+                        ? VersionListCard()
+                        : CustomSplitView(
+                            viewMode: SplitViewMode.Horizontal,
+                            initialWeight: 0.33,
+                            view1: VersionListCard(),
+                            view2: VersionDetailCard(
+                              selflink: true,
+                              editable: true,
+                            ),
+                          ),
+                    narrow(context)
+                        ? DeploymentListCard()
+                        : CustomSplitView(
+                            viewMode: SplitViewMode.Horizontal,
+                            initialWeight: 0.33,
+                            view1: DeploymentListCard(),
+                            view2: DeploymentDetailCard(
+                              selflink: true,
+                              editable: true,
+                            ),
+                          ),
+                    narrow(context)
+                        ? ArtifactListCard(SelectionProvider.api)
+                        : CustomSplitView(
+                            viewMode: SplitViewMode.Horizontal,
+                            view1: ArtifactListCard(SelectionProvider.api),
+                            view2: ArtifactDetailCard(
+                              selflink: true,
+                              editable: true,
+                            ),
+                          ),
                   ],
                 ),
               ),

--- a/viewer/lib/pages/deployment_detail.dart
+++ b/viewer/lib/pages/deployment_detail.dart
@@ -23,6 +23,7 @@ import '../components/artifact_detail.dart';
 import '../components/bottom_bar.dart';
 import '../components/home_button.dart';
 import '../components/split_view.dart';
+import '../helpers/media.dart';
 import '../helpers/tab_decoration.dart';
 import '../helpers/title.dart';
 
@@ -69,14 +70,17 @@ class DeploymentDetailPage extends StatelessWidget {
                 child: TabBarView(
                   children: [
                     DeploymentDetailCard(editable: true),
-                    CustomSplitView(
-                      viewMode: SplitViewMode.Horizontal,
-                      view1: ArtifactListCard(SelectionProvider.deployment),
-                      view2: ArtifactDetailCard(
-                        selflink: true,
-                        editable: true,
-                      ),
-                    ),
+                    narrow(context)
+                        ? ArtifactListCard(SelectionProvider.deployment)
+                        : CustomSplitView(
+                            viewMode: SplitViewMode.Horizontal,
+                            view1:
+                                ArtifactListCard(SelectionProvider.deployment),
+                            view2: ArtifactDetailCard(
+                              selflink: true,
+                              editable: true,
+                            ),
+                          ),
                   ],
                 ),
               ),

--- a/viewer/lib/pages/project_detail.dart
+++ b/viewer/lib/pages/project_detail.dart
@@ -23,6 +23,7 @@ import '../components/artifact_detail.dart';
 import '../components/bottom_bar.dart';
 import '../components/home_button.dart';
 import '../components/split_view.dart';
+import '../helpers/media.dart';
 import '../helpers/root.dart';
 import '../helpers/tab_decoration.dart';
 import '../helpers/title.dart';
@@ -69,24 +70,28 @@ class ProjectDetailPage extends StatelessWidget {
                 child: TabBarView(
                   children: [
                     ProjectDetailCard(editable: (root() == "/")),
-                    CustomSplitView(
-                      viewMode: SplitViewMode.Horizontal,
-                      initialWeight: 0.33,
-                      view1: ApiListCard(),
-                      view2: ApiDetailCard(
-                        selflink: true,
-                        editable: true,
-                      ),
-                    ),
-                    CustomSplitView(
-                      viewMode: SplitViewMode.Horizontal,
-                      initialWeight: 0.5,
-                      view1: ArtifactListCard(SelectionProvider.project),
-                      view2: ArtifactDetailCard(
-                        selflink: true,
-                        editable: true,
-                      ),
-                    ),
+                    narrow(context)
+                        ? ApiListCard()
+                        : CustomSplitView(
+                            viewMode: SplitViewMode.Horizontal,
+                            initialWeight: 0.33,
+                            view1: ApiListCard(),
+                            view2: ApiDetailCard(
+                              selflink: true,
+                              editable: true,
+                            ),
+                          ),
+                    narrow(context)
+                        ? ArtifactListCard(SelectionProvider.project)
+                        : CustomSplitView(
+                            viewMode: SplitViewMode.Horizontal,
+                            initialWeight: 0.5,
+                            view1: ArtifactListCard(SelectionProvider.project),
+                            view2: ArtifactDetailCard(
+                              selflink: true,
+                              editable: true,
+                            ),
+                          ),
                   ],
                 ),
               ),

--- a/viewer/lib/pages/spec_detail.dart
+++ b/viewer/lib/pages/spec_detail.dart
@@ -22,6 +22,7 @@ import '../components/artifact_detail.dart';
 import '../components/bottom_bar.dart';
 import '../components/home_button.dart';
 import '../components/split_view.dart';
+import '../helpers/media.dart';
 import '../helpers/tab_decoration.dart';
 import '../helpers/title.dart';
 
@@ -71,14 +72,16 @@ class SpecDetailPage extends StatelessWidget {
                 children: [
                   SpecDetailCard(editable: true),
                   SpecFileCard(),
-                  CustomSplitView(
-                    viewMode: SplitViewMode.Horizontal,
-                    view1: ArtifactListCard(SelectionProvider.spec),
-                    view2: ArtifactDetailCard(
-                      selflink: true,
-                      editable: true,
-                    ),
-                  ),
+                  narrow(context)
+                      ? ArtifactListCard(SelectionProvider.spec)
+                      : CustomSplitView(
+                          viewMode: SplitViewMode.Horizontal,
+                          view1: ArtifactListCard(SelectionProvider.spec),
+                          view2: ArtifactDetailCard(
+                            selflink: true,
+                            editable: true,
+                          ),
+                        ),
                 ],
               ),
             ),

--- a/viewer/lib/pages/version_detail.dart
+++ b/viewer/lib/pages/version_detail.dart
@@ -23,6 +23,7 @@ import '../components/artifact_detail.dart';
 import '../components/bottom_bar.dart';
 import '../components/home_button.dart';
 import '../components/split_view.dart';
+import '../helpers/media.dart';
 import '../helpers/tab_decoration.dart';
 import '../helpers/title.dart';
 
@@ -70,20 +71,25 @@ class VersionDetailPage extends StatelessWidget {
                 child: TabBarView(
                   children: [
                     VersionDetailCard(editable: true),
-                    CustomSplitView(
-                      viewMode: SplitViewMode.Horizontal,
-                      initialWeight: 0.33,
-                      view1: SpecListCard(),
-                      view2: SpecDetailCard(selflink: true, editable: true),
-                    ),
-                    CustomSplitView(
-                      viewMode: SplitViewMode.Horizontal,
-                      view1: ArtifactListCard(SelectionProvider.version),
-                      view2: ArtifactDetailCard(
-                        selflink: true,
-                        editable: true,
-                      ),
-                    ),
+                    narrow(context)
+                        ? SpecListCard()
+                        : CustomSplitView(
+                            viewMode: SplitViewMode.Horizontal,
+                            initialWeight: 0.33,
+                            view1: SpecListCard(),
+                            view2:
+                                SpecDetailCard(selflink: true, editable: true),
+                          ),
+                    narrow(context)
+                        ? ArtifactListCard(SelectionProvider.version)
+                        : CustomSplitView(
+                            viewMode: SplitViewMode.Horizontal,
+                            view1: ArtifactListCard(SelectionProvider.version),
+                            view2: ArtifactDetailCard(
+                              selflink: true,
+                              editable: true,
+                            ),
+                          ),
                   ],
                 ),
               ),


### PR DESCRIPTION
Two-column layouts don't work well on small screens (like phones).

This adds an initial improvement for small screens that automatically switches to a single-column display for narrow screens or windows - here are two screenshots showing the same view for wide and narrow screens:

![image](https://user-images.githubusercontent.com/405/214481668-6073e3b9-36d4-4016-8458-14f66fa2f805.png)

![image](https://user-images.githubusercontent.com/405/214481718-a3b5cc65-84a8-43c4-8255-a1273aea7cd3.png)

There are a few obvious to-dos that would improve the experience on mobile:
1. in single-column mode, taps on rows should go directly to the detail view instead of selecting something for display on the right hand side (which is not displayed in single-column mode)
2. we need to display a full-screen artifacts view when we drill down into artifacts, currently that is available but not hooked up