### PR TITLE
Use AutomaticKeepAlive mixin to prevent views in tabs from being rebuilt when tabs change.

### DIFF
--- a/viewer/lib/components/api_detail.dart
+++ b/viewer/lib/components/api_detail.dart
@@ -30,9 +30,12 @@ class ApiDetailCard extends StatefulWidget {
   _ApiDetailCardState createState() => _ApiDetailCardState();
 }
 
-class _ApiDetailCardState extends State<ApiDetailCard> {
+class _ApiDetailCardState extends State<ApiDetailCard>
+    with AutomaticKeepAliveClientMixin {
   ApiManager? apiManager;
   Selection? selection;
+  @override
+  bool get wantKeepAlive => true;
 
   void managerListener() {
     setState(() {});
@@ -74,9 +77,11 @@ class _ApiDetailCardState extends State<ApiDetailCard> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     if (apiManager?.value == null) {
       return emptyCard(context, "api");
     }
+
     Function? selflink = onlyIf(widget.selflink, () {
       Api api = (apiManager?.value)!;
       Navigator.pushNamed(

--- a/viewer/lib/components/api_list.dart
+++ b/viewer/lib/components/api_list.dart
@@ -30,9 +30,12 @@ class ApiListCard extends StatefulWidget {
   _ApiListCardState createState() => _ApiListCardState();
 }
 
-class _ApiListCardState extends State<ApiListCard> {
+class _ApiListCardState extends State<ApiListCard>
+    with AutomaticKeepAliveClientMixin {
   ApiService? apiService;
   PagewiseLoadController<Api>? pageLoadController;
+  @override
+  bool get wantKeepAlive => true;
 
   _ApiListCardState() {
     apiService = ApiService();
@@ -44,6 +47,7 @@ class _ApiListCardState extends State<ApiListCard> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return ObservableStringProvider(
       observable: ObservableString(),
       child: Card(

--- a/viewer/lib/components/artifact_detail.dart
+++ b/viewer/lib/components/artifact_detail.dart
@@ -36,9 +36,12 @@ class ArtifactDetailCard extends StatefulWidget {
   _ArtifactDetailCardState createState() => _ArtifactDetailCardState();
 }
 
-class _ArtifactDetailCardState extends State<ArtifactDetailCard> {
+class _ArtifactDetailCardState extends State<ArtifactDetailCard>
+    with AutomaticKeepAliveClientMixin {
   ArtifactManager? artifactManager;
   Selection? selection;
+  @override
+  bool get wantKeepAlive => true;
 
   void managerListener() {
     setState(() {});
@@ -80,9 +83,11 @@ class _ArtifactDetailCardState extends State<ArtifactDetailCard> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     if (artifactManager?.value == null) {
       return emptyCard(context, "artifact");
     }
+
     Function? selflink = onlyIf(widget.selflink, () {
       Artifact artifact = (artifactManager?.value)!;
       Navigator.pushNamed(

--- a/viewer/lib/components/artifact_list.dart
+++ b/viewer/lib/components/artifact_list.dart
@@ -40,11 +40,14 @@ class ArtifactListCard extends StatefulWidget {
   _ArtifactListCardState createState() => _ArtifactListCardState();
 }
 
-class _ArtifactListCardState extends State<ArtifactListCard> {
+class _ArtifactListCardState extends State<ArtifactListCard>
+    with AutomaticKeepAliveClientMixin {
   late ObservableString observableSubjectName;
   String? subjectName;
   ArtifactService? artifactService;
   PagewiseLoadController<Artifact>? pageLoadController;
+  @override
+  bool get wantKeepAlive => true;
 
   _ArtifactListCardState() {
     artifactService = ArtifactService();
@@ -80,6 +83,7 @@ class _ArtifactListCardState extends State<ArtifactListCard> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     Function add = () {
       final selection = SelectionProvider.of(context);
       showDialog(

--- a/viewer/lib/components/deployment_detail.dart
+++ b/viewer/lib/components/deployment_detail.dart
@@ -30,10 +30,13 @@ class DeploymentDetailCard extends StatefulWidget {
   _DeploymentDetailCardState createState() => _DeploymentDetailCardState();
 }
 
-class _DeploymentDetailCardState extends State<DeploymentDetailCard> {
+class _DeploymentDetailCardState extends State<DeploymentDetailCard>
+    with AutomaticKeepAliveClientMixin {
   ApiManager? apiManager;
   DeploymentManager? deploymentManager;
   Selection? selection;
+  @override
+  bool get wantKeepAlive => true;
 
   void managerListener() {
     setState(() {});
@@ -91,9 +94,11 @@ class _DeploymentDetailCardState extends State<DeploymentDetailCard> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     if (deploymentManager?.value == null) {
       return emptyCard(context, "deployment");
     }
+
     Function? selflink = onlyIf(widget.selflink, () {
       ApiDeployment deployment = (deploymentManager?.value)!;
       Navigator.pushNamed(
@@ -116,7 +121,6 @@ class _DeploymentDetailCardState extends State<DeploymentDetailCard> {
             );
           });
     });
-
     Api? api = apiManager!.value;
     ApiDeployment deployment = deploymentManager!.value!;
     return Card(

--- a/viewer/lib/components/deployment_list.dart
+++ b/viewer/lib/components/deployment_list.dart
@@ -31,9 +31,12 @@ class DeploymentListCard extends StatefulWidget {
   _DeploymentListCardState createState() => _DeploymentListCardState();
 }
 
-class _DeploymentListCardState extends State<DeploymentListCard> {
+class _DeploymentListCardState extends State<DeploymentListCard>
+    with AutomaticKeepAliveClientMixin {
   DeploymentService? deploymentService;
   PagewiseLoadController<ApiDeployment>? pageLoadController;
+  @override
+  bool get wantKeepAlive => true;
 
   _DeploymentListCardState() {
     deploymentService = DeploymentService();
@@ -46,6 +49,7 @@ class _DeploymentListCardState extends State<DeploymentListCard> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return ObservableStringProvider(
       observable: ObservableString(),
       child: Card(

--- a/viewer/lib/components/project_detail.dart
+++ b/viewer/lib/components/project_detail.dart
@@ -18,6 +18,7 @@ import '../components/detail_rows.dart';
 import '../components/dialog_builder.dart';
 import '../components/empty.dart';
 import '../components/project_edit.dart';
+import '../components/empty.dart';
 import '../models/project.dart';
 import '../models/selection.dart';
 import '../service/registry.dart';
@@ -30,9 +31,12 @@ class ProjectDetailCard extends StatefulWidget {
   _ProjectDetailCardState createState() => _ProjectDetailCardState();
 }
 
-class _ProjectDetailCardState extends State<ProjectDetailCard> {
+class _ProjectDetailCardState extends State<ProjectDetailCard>
+    with AutomaticKeepAliveClientMixin {
   ProjectManager? projectManager;
   Selection? selection;
+  @override
+  bool get wantKeepAlive => true;
 
   void managerListener() {
     setState(() {});
@@ -74,9 +78,11 @@ class _ProjectDetailCardState extends State<ProjectDetailCard> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     if (projectManager?.value == null) {
       return emptyCard(context, "project");
     }
+
     Function? selflink = onlyIf(widget.selflink, () {
       Project project = (projectManager?.value)!;
       Navigator.pushNamed(

--- a/viewer/lib/components/project_list.dart
+++ b/viewer/lib/components/project_list.dart
@@ -32,9 +32,12 @@ class ProjectListCard extends StatefulWidget {
   _ProjectListCardState createState() => _ProjectListCardState();
 }
 
-class _ProjectListCardState extends State<ProjectListCard> {
+class _ProjectListCardState extends State<ProjectListCard>
+    with AutomaticKeepAliveClientMixin {
   ProjectService? projectService;
   PagewiseLoadController<Project>? pageLoadController;
+  @override
+  bool get wantKeepAlive => true;
 
   _ProjectListCardState() {
     projectService = ProjectService();
@@ -45,6 +48,7 @@ class _ProjectListCardState extends State<ProjectListCard> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return ObservableStringProvider(
       observable: ObservableString(),
       child: Card(

--- a/viewer/lib/components/spec_detail.dart
+++ b/viewer/lib/components/spec_detail.dart
@@ -33,11 +33,14 @@ class SpecDetailCard extends StatefulWidget {
   _SpecDetailCardState createState() => _SpecDetailCardState();
 }
 
-class _SpecDetailCardState extends State<SpecDetailCard> {
+class _SpecDetailCardState extends State<SpecDetailCard>
+    with AutomaticKeepAliveClientMixin {
   ApiManager? apiManager;
   VersionManager? versionManager;
   SpecManager? specManager;
   Selection? selection;
+  @override
+  bool get wantKeepAlive => true;
 
   void managerListener() {
     setState(() {});
@@ -109,9 +112,11 @@ class _SpecDetailCardState extends State<SpecDetailCard> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     if (specManager?.value == null) {
       return emptyCard(context, "spec");
     }
+
     Function? selflink = onlyIf(widget.selflink, () {
       ApiSpec spec = (specManager?.value)!;
       Navigator.pushNamed(

--- a/viewer/lib/components/spec_list.dart
+++ b/viewer/lib/components/spec_list.dart
@@ -30,9 +30,12 @@ class SpecListCard extends StatefulWidget {
   _SpecListCardState createState() => _SpecListCardState();
 }
 
-class _SpecListCardState extends State<SpecListCard> {
+class _SpecListCardState extends State<SpecListCard>
+    with AutomaticKeepAliveClientMixin {
   SpecService? specService;
   PagewiseLoadController<ApiSpec>? pageLoadController;
+  @override
+  bool get wantKeepAlive => true;
 
   _SpecListCardState() {
     specService = SpecService();
@@ -44,6 +47,7 @@ class _SpecListCardState extends State<SpecListCard> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return ObservableStringProvider(
       observable: ObservableString(),
       child: Card(

--- a/viewer/lib/components/split_view.dart
+++ b/viewer/lib/components/split_view.dart
@@ -17,28 +17,47 @@ import 'package:split_view/split_view.dart';
 
 enum Side { top, bottom, right, left }
 
-class CustomSplitView extends SplitView {
+class CustomSplitView extends StatefulWidget {
+  final Widget? view1;
+  final Widget? view2;
+  final SplitViewMode? viewMode;
+  final double initialWeight;
+
   CustomSplitView({
-    required SplitViewMode viewMode,
-    Widget? view1,
-    Widget? view2,
-    double initialWeight = 0.5,
-  }) : super(
-          viewMode: viewMode,
-          children: [
-            ThresholdBox(
-                child: view1,
-                side: (viewMode == SplitViewMode.Vertical)
-                    ? Side.top
-                    : Side.right),
-            ThresholdBox(
-                child: view2,
-                side: (viewMode == SplitViewMode.Vertical)
-                    ? Side.bottom
-                    : Side.left)
-          ],
-          gripSize: 10,
-        );
+    this.viewMode,
+    this.view1,
+    this.view2,
+    this.initialWeight = 0.5,
+  });
+
+  _CustomSplitViewState createState() => _CustomSplitViewState();
+}
+
+class _CustomSplitViewState extends State<CustomSplitView>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return SplitView(
+      viewMode: widget.viewMode!,
+      children: [
+        ThresholdBox(
+            child: widget.view1,
+            side: (widget.viewMode == SplitViewMode.Vertical)
+                ? Side.top
+                : Side.right),
+        ThresholdBox(
+            child: widget.view2,
+            side: (widget.viewMode == SplitViewMode.Vertical)
+                ? Side.bottom
+                : Side.left)
+      ],
+      gripSize: 10,
+    );
+  }
 }
 
 class ThresholdBox extends StatelessWidget {

--- a/viewer/lib/components/version_detail.dart
+++ b/viewer/lib/components/version_detail.dart
@@ -18,6 +18,7 @@ import '../components/detail_rows.dart';
 import '../components/dialog_builder.dart';
 import '../components/empty.dart';
 import '../components/version_edit.dart';
+import '../components/empty.dart';
 import '../models/selection.dart';
 import '../models/version.dart';
 import '../service/registry.dart';
@@ -30,10 +31,13 @@ class VersionDetailCard extends StatefulWidget {
   _VersionDetailCardState createState() => _VersionDetailCardState();
 }
 
-class _VersionDetailCardState extends State<VersionDetailCard> {
+class _VersionDetailCardState extends State<VersionDetailCard>
+    with AutomaticKeepAliveClientMixin {
   ApiManager? apiManager;
   VersionManager? versionManager;
   Selection? selection;
+  @override
+  bool get wantKeepAlive => true;
 
   void managerListener() {
     setState(() {});
@@ -90,6 +94,7 @@ class _VersionDetailCardState extends State<VersionDetailCard> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     if (versionManager?.value == null) {
       return emptyCard(context, "version");
     }

--- a/viewer/lib/components/version_list.dart
+++ b/viewer/lib/components/version_list.dart
@@ -31,9 +31,12 @@ class VersionListCard extends StatefulWidget {
   _VersionListCardState createState() => _VersionListCardState();
 }
 
-class _VersionListCardState extends State<VersionListCard> {
+class _VersionListCardState extends State<VersionListCard>
+    with AutomaticKeepAliveClientMixin {
   VersionService? versionService;
   PagewiseLoadController<ApiVersion>? pageLoadController;
+  @override
+  bool get wantKeepAlive => true;
 
   _VersionListCardState() {
     versionService = VersionService();
@@ -46,6 +49,7 @@ class _VersionListCardState extends State<VersionListCard> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return ObservableStringProvider(
       observable: ObservableString(),
       child: Card(

--- a/viewer/lib/pages/api_detail.dart
+++ b/viewer/lib/pages/api_detail.dart
@@ -45,7 +45,7 @@ class ApiDetailPage extends StatelessWidget {
       selection: selection,
       child: DefaultTabController(
         length: 4,
-        animationDuration: Duration.zero,
+        animationDuration: Duration(milliseconds: 100),
         child: Scaffold(
           appBar: AppBar(
             centerTitle: true,

--- a/viewer/lib/pages/deployment_detail.dart
+++ b/viewer/lib/pages/deployment_detail.dart
@@ -45,7 +45,7 @@ class DeploymentDetailPage extends StatelessWidget {
       selection: selection,
       child: DefaultTabController(
         length: 2,
-        animationDuration: Duration.zero,
+        animationDuration: Duration(milliseconds: 100),
         initialIndex: 0,
         child: Scaffold(
           appBar: AppBar(

--- a/viewer/lib/pages/project_detail.dart
+++ b/viewer/lib/pages/project_detail.dart
@@ -44,7 +44,7 @@ class ProjectDetailPage extends StatelessWidget {
       selection: selection,
       child: DefaultTabController(
         length: 3,
-        animationDuration: Duration.zero,
+        animationDuration: Duration(milliseconds: 100),
         initialIndex: 1,
         child: Scaffold(
           appBar: AppBar(

--- a/viewer/lib/pages/spec_detail.dart
+++ b/viewer/lib/pages/spec_detail.dart
@@ -46,7 +46,7 @@ class SpecDetailPage extends StatelessWidget {
       selection: selection,
       child: DefaultTabController(
         length: 3,
-        animationDuration: Duration.zero,
+        animationDuration: Duration(milliseconds: 100),
         initialIndex: 1,
         child: Scaffold(
           appBar: AppBar(

--- a/viewer/lib/pages/version_detail.dart
+++ b/viewer/lib/pages/version_detail.dart
@@ -45,7 +45,7 @@ class VersionDetailPage extends StatelessWidget {
       selection: selection,
       child: DefaultTabController(
         length: 3,
-        animationDuration: Duration.zero,
+        animationDuration: Duration(milliseconds: 100),
         initialIndex: 1,
         child: Scaffold(
           appBar: AppBar(


### PR DESCRIPTION
When the tab views were added (#53), I started noticing that tab contents would disappear after switching views a few times. The fact that it didn't happen right away suggested that it was related to memory management (garbage collection), and some searching led to [this issue](https://github.com/flutter/flutter/issues/19116) that recommended using the `AutomaticKeepAliveClientMixin` to prevent tabs from being removed and regenerated. This commit includes those recommended changes for views in tabs and also  tweaks the duration used to animate transitions between tab views. With this change, the disappearing tab view problem seems to be gone.