### PR TITLE
Simplify names in titles by removing the project/location segments.

### DIFF
--- a/viewer/lib/components/api_detail.dart
+++ b/viewer/lib/components/api_detail.dart
@@ -105,7 +105,7 @@ class _ApiDetailCardState extends State<ApiDetailCard> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           ResourceNameButtonRow(
-            name: api.name.split("/").sublist(2).join("/"),
+            name: api.name.split("/").sublist(4).join("/"),
             show: selflink as void Function()?,
             edit: editable as void Function()?,
           ),

--- a/viewer/lib/components/api_edit.dart
+++ b/viewer/lib/components/api_edit.dart
@@ -95,7 +95,7 @@ class EditAPIFormState extends State<EditAPIForm> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
-            Text(api.name.split("/").sublist(2).join("/")),
+            Text(api.name.split("/").sublist(4).join("/")),
             ListTile(
               title: TextFormField(
                 controller: displayNameController,

--- a/viewer/lib/components/deployment_edit.dart
+++ b/viewer/lib/components/deployment_edit.dart
@@ -96,7 +96,7 @@ class EditDeploymentFormState extends State<EditDeploymentForm> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
-            Text(deployment.name),
+            Text(deployment.name.split("/").sublist(4).join("/")),
             ListTile(
               title: TextFormField(
                 controller: displayNameController,

--- a/viewer/lib/components/spec_edit.dart
+++ b/viewer/lib/components/spec_edit.dart
@@ -92,7 +92,7 @@ class EditSpecFormState extends State<EditSpecForm> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
-            Text(spec.name),
+            Text(spec.name.split("/").sublist(4).join("/")),
             ListTile(
               title: TextFormField(
                 controller: descriptionController,

--- a/viewer/lib/components/version_edit.dart
+++ b/viewer/lib/components/version_edit.dart
@@ -98,7 +98,7 @@ class EditVersionFormState extends State<EditVersionForm> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
-            Text(version.name),
+            Text(version.name.split("/").sublist(4).join("/")),
             ListTile(
               title: TextFormField(
                 controller: displayNameController,


### PR DESCRIPTION
This replaces "projects/myproject/locations/global/apis/..." with "apis/..." by removing the first four segments of path names before they are used in titles. This should probably be moved into a helper function in the future.