### PR TITLE
Revision artifacts

### DIFF
--- a/viewer/lib/components/api_list.dart
+++ b/viewer/lib/components/api_list.dart
@@ -26,6 +26,9 @@ typedef ApiSelectionHandler = Function(BuildContext context, Api api);
 
 // ApiListCard is a card that displays a list of apis.
 class ApiListCard extends StatefulWidget {
+  final bool singleColumn;
+  ApiListCard({required this.singleColumn});
+
   @override
   _ApiListCardState createState() => _ApiListCardState();
 }
@@ -60,6 +63,7 @@ class _ApiListCardState extends State<ApiListCard>
                 null,
                 apiService,
                 pageLoadController,
+                widget.singleColumn,
               ),
             ),
           ],
@@ -74,11 +78,13 @@ class ApiListView extends StatefulWidget {
   final ApiSelectionHandler? selectionHandler;
   final ApiService? apiService;
   final PagewiseLoadController<Api>? pageLoadController;
+  final bool singleColumn;
 
   ApiListView(
     this.selectionHandler,
     this.apiService,
     this.pageLoadController,
+    this.singleColumn,
   );
 
   @override
@@ -164,7 +170,14 @@ class _ApiListViewState extends State<ApiListView> {
       dense: false,
       onTap: () async {
         setState(() {
-          selectedIndex = index;
+          if (widget.singleColumn) {
+            Navigator.pushNamed(
+              context,
+              api.routeNameForDetail(),
+            );
+          } else {
+            selectedIndex = index;
+          }
         });
         Selection? selection = SelectionProvider.of(context);
         selection?.updateApiName(api.name);

--- a/viewer/lib/components/artifact_list.dart
+++ b/viewer/lib/components/artifact_list.dart
@@ -34,7 +34,9 @@ typedef ArtifactSelectionHandler = Function(
 // ArtifactListCard is a card that displays a list of artifacts.
 class ArtifactListCard extends StatefulWidget {
   final ObservableStringFn getObservableResourceName;
-  ArtifactListCard(this.getObservableResourceName);
+  final bool singleColumn;
+  ArtifactListCard(this.getObservableResourceName,
+      {required this.singleColumn});
 
   @override
   _ArtifactListCardState createState() => _ArtifactListCardState();
@@ -112,6 +114,7 @@ class _ArtifactListCardState extends State<ArtifactListCard>
                 null,
                 artifactService,
                 pageLoadController,
+                widget.singleColumn,
               ),
             ),
           ],
@@ -127,12 +130,14 @@ class ArtifactListView extends StatefulWidget {
   final ArtifactSelectionHandler? selectionHandler;
   final ArtifactService? artifactService;
   final PagewiseLoadController<Artifact>? pageLoadController;
+  final bool singleColumn;
 
   ArtifactListView(
     this.getObservableResourceName,
     this.selectionHandler,
     this.artifactService,
     this.pageLoadController,
+    this.singleColumn,
   );
   @override
   _ArtifactListViewState createState() => _ArtifactListViewState();
@@ -218,7 +223,14 @@ class _ArtifactListViewState extends State<ArtifactListView> {
       dense: false,
       onTap: () async {
         setState(() {
-          selectedIndex = index;
+          if (widget.singleColumn) {
+            Navigator.pushNamed(
+              context,
+              artifact.routeNameForDetail(),
+            );
+          } else {
+            selectedIndex = index;
+          }
         });
         Selection? selection = SelectionProvider.of(context);
         selection?.updateArtifactName(artifact.name);

--- a/viewer/lib/components/artifact_list.dart
+++ b/viewer/lib/components/artifact_list.dart
@@ -199,26 +199,18 @@ class _ArtifactListViewState extends State<ArtifactListView> {
   }
 
   Widget _itemBuilder(context, Artifact artifact, index) {
-    String? artifactInfoLink;
-    switch (artifact.mimeType) {
-      case "application/octet-stream;type=gnostic.metrics.Vocabulary":
-        artifactInfoLink =
-            "https://github.com/google/gnostic/blob/master/metrics/vocabulary.proto#L27";
-        break;
-      case "application/octet-stream;type=gnostic.metrics.Complexity":
-        artifactInfoLink =
-            "https://github.com/google/gnostic/blob/master/metrics/complexity.proto#L23";
-        break;
-      case "application/octet-stream;type=google.cloud.apigeeregistry.applications.v1alpha1.Lint":
-        artifactInfoLink =
-            "https://github.com/apigeeregistry/blob/main/google/cloud/apigeeregistry/v1/registry_lint.proto#L38";
-        break;
-      case "application/octet-stream;type=google.cloud.apigeeregistry.applications.v1alpha1.LintStats":
-        artifactInfoLink =
-            "https://github.com/apigeeregistry/blob/main/google/cloud/apigeeregistry/v1/registry_lint.proto#L91";
-        break;
+    if (index == 0) {
+      Future.delayed(const Duration(), () {
+        Selection? selection = SelectionProvider.of(context);
+        if ((selection != null) && (selection.artifactName.value == "")) {
+          selection.updateArtifactName(artifact.name);
+          setState(() {
+            selectedIndex = 0;
+          });
+        }
+      });
     }
-    bool canDelete = artifact.mimeType == "text/plain";
+
     return ListTile(
       title: Text(artifact.nameForDisplay()),
       subtitle: widgetForArtifactValue(artifact),
@@ -232,40 +224,15 @@ class _ArtifactListViewState extends State<ArtifactListView> {
         selection?.updateArtifactName(artifact.name);
         widget.selectionHandler?.call(context, artifact);
       },
-      trailing: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if (artifactInfoLink != null)
-            IconButton(
-                icon: Icon(Icons.info),
-                tooltip: "info",
-                onPressed: () async {
-                  if (await canLaunchUrl(Uri.parse(artifactInfoLink!))) {
-                    await launchUrl(Uri.parse(artifactInfoLink));
-                  } else {
-                    throw 'Could not launch $artifactInfoLink';
-                  }
-                }),
-          if (canDelete)
-            IconButton(
-              icon: Icon(Icons.delete),
-              tooltip: "delete",
-              onPressed: () {
-                final selection = SelectionProvider.of(context)!;
-                selection.updateArtifactName(artifact.name);
-                showDialog(
-                    context: context,
-                    builder: (BuildContext context) {
-                      return SelectionProvider(
-                        selection: selection,
-                        child: AlertDialog(
-                          content: DeleteArtifactForm(),
-                        ),
-                      );
-                    });
-              },
-            ),
-        ],
+      trailing: IconButton(
+        icon: Icon(Icons.open_in_new),
+        tooltip: "open",
+        onPressed: () {
+          Navigator.pushNamed(
+            context,
+            artifact.routeNameForDetail(),
+          );
+        },
       ),
     );
   }

--- a/viewer/lib/components/deployment_list.dart
+++ b/viewer/lib/components/deployment_list.dart
@@ -27,6 +27,9 @@ typedef DeploymentSelectionHandler = Function(
 
 // DeploymentListCard is a card that displays a list of deployments.
 class DeploymentListCard extends StatefulWidget {
+  final bool singleColumn;
+  DeploymentListCard({required this.singleColumn});
+
   @override
   _DeploymentListCardState createState() => _DeploymentListCardState();
 }
@@ -62,6 +65,7 @@ class _DeploymentListCardState extends State<DeploymentListCard>
                 null,
                 deploymentService,
                 pageLoadController,
+                widget.singleColumn,
               ),
             ),
           ],
@@ -76,11 +80,13 @@ class DeploymentListView extends StatefulWidget {
   final DeploymentSelectionHandler? selectionHandler;
   final DeploymentService? deploymentService;
   final PagewiseLoadController<ApiDeployment>? pageLoadController;
+  final bool singleColumn;
 
   DeploymentListView(
     this.selectionHandler,
     this.deploymentService,
     this.pageLoadController,
+    this.singleColumn,
   );
 
   @override
@@ -165,7 +171,14 @@ class _DeploymentListViewState extends State<DeploymentListView> {
       dense: false,
       onTap: () async {
         setState(() {
-          selectedIndex = index;
+          if (widget.singleColumn) {
+            Navigator.pushNamed(
+              context,
+              deployment.routeNameForDetail(),
+            );
+          } else {
+            selectedIndex = index;
+          }
         });
         Selection? selection = SelectionProvider.of(context);
         selection?.updateDeploymentName(deployment.name);

--- a/viewer/lib/components/home.dart
+++ b/viewer/lib/components/home.dart
@@ -32,11 +32,15 @@ class Home extends StatelessWidget {
           children: [
             Expanded(
               child: narrow(context)
-                  ? ProjectListCard()
+                  ? ProjectListCard(
+                      singleColumn: true,
+                    )
                   : CustomSplitView(
                       viewMode: SplitViewMode.Horizontal,
                       initialWeight: 0.33,
-                      view1: ProjectListCard(),
+                      view1: ProjectListCard(
+                        singleColumn: false,
+                      ),
                       view2: ProjectDetailCard(selflink: true, editable: true),
                     ),
             ),

--- a/viewer/lib/components/project_list.dart
+++ b/viewer/lib/components/project_list.dart
@@ -28,6 +28,9 @@ typedef ProjectSelectionHandler = Function(
 
 // ProjectListCard is a card that displays a list of projects.
 class ProjectListCard extends StatefulWidget {
+  final bool singleColumn;
+  ProjectListCard({required this.singleColumn});
+
   @override
   _ProjectListCardState createState() => _ProjectListCardState();
 }
@@ -61,6 +64,7 @@ class _ProjectListCardState extends State<ProjectListCard>
                 null,
                 projectService,
                 pageLoadController,
+                widget.singleColumn,
               ),
             ),
           ],
@@ -75,11 +79,13 @@ class ProjectListView extends StatefulWidget {
   final ProjectSelectionHandler? selectionHandler;
   final ProjectService? projectService;
   final PagewiseLoadController<Project>? pageLoadController;
+  final bool singleColumn;
 
   ProjectListView(
     this.selectionHandler,
     this.projectService,
     this.pageLoadController,
+    this.singleColumn,
   );
 
   @override
@@ -141,7 +147,14 @@ class _ProjectListViewState extends State<ProjectListView> {
       dense: false,
       onTap: () async {
         setState(() {
-          selectedIndex = index;
+          if (widget.singleColumn) {
+            Navigator.pushNamed(
+              context,
+              project.routeNameForDetail(),
+            );
+          } else {
+            selectedIndex = index;
+          }
         });
         Selection? selection = SelectionProvider.of(context);
         selection?.updateProjectName(project.name);

--- a/viewer/lib/components/spec_file.dart
+++ b/viewer/lib/components/spec_file.dart
@@ -175,57 +175,53 @@ class _SpecFileCardState extends State<SpecFileCard> {
     } else {
       if (this.items == null) {
         // single-file view
-        return CustomSplitView(
-          viewMode: SplitViewMode.Horizontal,
-          view1: Card(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                PanelNameRow(
-                  name: specManager!.value!.filename,
-                  button: IconButton(
-                    color: Colors.black,
-                    icon: Icon(Icons.open_in_new),
-                    tooltip: "Viewer",
-                    onPressed: () {
-                      var address = rendererServiceAddress();
-                      if ((address != "SPEC_RENDERER_SERVICE") &&
-                          (address != "")) {
-                        launchUrl(Uri.parse(
-                            address + "/" + specManager!.value!.name));
-                      } else {
-                        AlertDialog alert = AlertDialog(
-                          content: Text("Spec renderer service not configured"),
-                          actions: [
-                            TextButton(
-                              child: Text("OK"),
-                              onPressed: () {
-                                Navigator.of(context).pop(); // dismiss dialog
-                              },
-                            ),
-                          ],
-                        );
-                        // show the dialog
-                        showDialog(
-                          context: context,
-                          builder: (BuildContext context) {
-                            return alert;
-                          },
-                        );
-                      }
-                    },
-                  ),
+        return Card(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              PanelNameRow(
+                name: specManager!.value!.filename,
+                button: IconButton(
+                  color: Colors.black,
+                  icon: Icon(Icons.open_in_new),
+                  tooltip: "Viewer",
+                  onPressed: () {
+                    var address = rendererServiceAddress();
+                    if ((address != "SPEC_RENDERER_SERVICE") &&
+                        (address != "")) {
+                      launchUrl(
+                          Uri.parse(address + "/" + specManager!.value!.name));
+                    } else {
+                      AlertDialog alert = AlertDialog(
+                        content: Text("Spec renderer service not configured"),
+                        actions: [
+                          TextButton(
+                            child: Text("OK"),
+                            onPressed: () {
+                              Navigator.of(context).pop(); // dismiss dialog
+                            },
+                          ),
+                        ],
+                      );
+                      // show the dialog
+                      showDialog(
+                        context: context,
+                        builder: (BuildContext context) {
+                          return alert;
+                        },
+                      );
+                    }
+                  },
                 ),
-                Expanded(
-                  child: Container(
-                    width: double.infinity,
-                    child: CodeView(body),
-                  ),
+              ),
+              Expanded(
+                child: Container(
+                  width: double.infinity,
+                  child: CodeView(body),
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
-          view2: SpecOutlineCard(),
         );
       } else {
         // multi-file view

--- a/viewer/lib/components/spec_list.dart
+++ b/viewer/lib/components/spec_list.dart
@@ -26,6 +26,9 @@ typedef SpecSelectionHandler = Function(BuildContext context, ApiSpec spec);
 
 // SpecListCard is a card that displays a list of specs.
 class SpecListCard extends StatefulWidget {
+  final bool singleColumn;
+  SpecListCard({required this.singleColumn});
+
   @override
   _SpecListCardState createState() => _SpecListCardState();
 }
@@ -60,6 +63,7 @@ class _SpecListCardState extends State<SpecListCard>
                 null,
                 specService,
                 pageLoadController,
+                widget.singleColumn,
               ),
             ),
           ],
@@ -74,11 +78,13 @@ class SpecListView extends StatefulWidget {
   final SpecSelectionHandler? selectionHandler;
   final SpecService? specService;
   final PagewiseLoadController<ApiSpec>? pageLoadController;
+  final bool singleColumn;
 
   SpecListView(
     this.selectionHandler,
     this.specService,
     this.pageLoadController,
+    this.singleColumn,
   );
 
   @override
@@ -164,7 +170,14 @@ class _SpecListViewState extends State<SpecListView> {
       dense: false,
       onTap: () async {
         setState(() {
-          selectedIndex = index;
+          if (widget.singleColumn) {
+            Navigator.pushNamed(
+              context,
+              spec.routeNameForDetail(),
+            );
+          } else {
+            selectedIndex = index;
+          }
         });
         Selection? selection = SelectionProvider.of(context);
         selection?.updateSpecName(spec.name);

--- a/viewer/lib/components/spec_picker.dart
+++ b/viewer/lib/components/spec_picker.dart
@@ -38,16 +38,22 @@ class SpecPicker extends StatelessWidget {
               child: Row(
                 children: [
                   Expanded(
-                    child: ProjectListCard(),
+                    child: ProjectListCard(
+                      singleColumn: false,
+                    ),
                   ),
                   Expanded(
-                    child: ApiListCard(),
+                    child: ApiListCard(
+                      singleColumn: false,
+                    ),
                   ),
                   Expanded(
-                    child: VersionListCard(),
+                    child: VersionListCard(
+                      singleColumn: false,
+                    ),
                   ),
                   Expanded(
-                    child: SpecListCard(),
+                    child: SpecListCard(singleColumn: false),
                   ),
                 ],
               ),

--- a/viewer/lib/components/version_list.dart
+++ b/viewer/lib/components/version_list.dart
@@ -27,6 +27,9 @@ typedef VersionSelectionHandler = Function(
 
 // VersionListCard is a card that displays a list of versions.
 class VersionListCard extends StatefulWidget {
+  final bool singleColumn;
+  VersionListCard({required this.singleColumn});
+
   @override
   _VersionListCardState createState() => _VersionListCardState();
 }
@@ -62,6 +65,7 @@ class _VersionListCardState extends State<VersionListCard>
                 null,
                 versionService,
                 pageLoadController,
+                widget.singleColumn,
               ),
             ),
           ],
@@ -76,11 +80,13 @@ class VersionListView extends StatefulWidget {
   final VersionSelectionHandler? selectionHandler;
   final VersionService? versionService;
   final PagewiseLoadController<ApiVersion>? pageLoadController;
+  final bool singleColumn;
 
   VersionListView(
     this.selectionHandler,
     this.versionService,
     this.pageLoadController,
+    this.singleColumn,
   );
 
   @override
@@ -165,7 +171,14 @@ class _VersionListViewState extends State<VersionListView> {
       dense: false,
       onTap: () async {
         setState(() {
-          selectedIndex = index;
+          if (widget.singleColumn) {
+            Navigator.pushNamed(
+              context,
+              version.routeNameForDetail(),
+            );
+          } else {
+            selectedIndex = index;
+          }
         });
         Selection? selection = SelectionProvider.of(context);
         selection?.updateVersionName(version.name);

--- a/viewer/lib/pages/api_detail.dart
+++ b/viewer/lib/pages/api_detail.dart
@@ -93,32 +93,44 @@ class ApiDetailPage extends StatelessWidget {
                   children: [
                     ApiDetailCard(editable: true),
                     narrow(context)
-                        ? VersionListCard()
+                        ? VersionListCard(
+                            singleColumn: true,
+                          )
                         : CustomSplitView(
                             viewMode: SplitViewMode.Horizontal,
                             initialWeight: 0.33,
-                            view1: VersionListCard(),
+                            view1: VersionListCard(singleColumn: false),
                             view2: VersionDetailCard(
                               selflink: true,
                               editable: true,
                             ),
                           ),
                     narrow(context)
-                        ? DeploymentListCard()
+                        ? DeploymentListCard(
+                            singleColumn: true,
+                          )
                         : CustomSplitView(
                             viewMode: SplitViewMode.Horizontal,
                             initialWeight: 0.33,
-                            view1: DeploymentListCard(),
+                            view1: DeploymentListCard(
+                              singleColumn: false,
+                            ),
                             view2: DeploymentDetailCard(
                               selflink: true,
                               editable: true,
                             ),
                           ),
                     narrow(context)
-                        ? ArtifactListCard(SelectionProvider.api)
+                        ? ArtifactListCard(
+                            SelectionProvider.api,
+                            singleColumn: true,
+                          )
                         : CustomSplitView(
                             viewMode: SplitViewMode.Horizontal,
-                            view1: ArtifactListCard(SelectionProvider.api),
+                            view1: ArtifactListCard(
+                              SelectionProvider.api,
+                              singleColumn: false,
+                            ),
                             view2: ArtifactDetailCard(
                               selflink: true,
                               editable: true,

--- a/viewer/lib/pages/api_list.dart
+++ b/viewer/lib/pages/api_list.dart
@@ -80,6 +80,7 @@ class _ApiListPageState extends State<ApiListPage> {
               },
               apiService,
               pageLoadController,
+              true,
             ),
           ),
         ),

--- a/viewer/lib/pages/artifact_detail.dart
+++ b/viewer/lib/pages/artifact_detail.dart
@@ -13,12 +13,11 @@
 // limitations under the License.
 
 import 'package:flutter/material.dart';
-import 'package:split_view/split_view.dart';
 import '../models/selection.dart';
 import '../components/artifact_detail.dart';
 import '../components/bottom_bar.dart';
 import '../components/home_button.dart';
-import '../components/split_view.dart';
+import '../helpers/title.dart';
 
 class ArtifactDetailPage extends StatelessWidget {
   final String? name;
@@ -37,7 +36,7 @@ class ArtifactDetailPage extends StatelessWidget {
       child: Scaffold(
         appBar: AppBar(
           centerTitle: true,
-          title: Text("Artifact Details"),
+          title: Text(pageTitle(this.name) ?? "Artifact Details"),
           actions: <Widget>[
             homeButton(context),
           ],
@@ -45,12 +44,7 @@ class ArtifactDetailPage extends StatelessWidget {
         body: Column(
           children: [
             Expanded(
-              child: CustomSplitView(
-                initialWeight: 0.33,
-                viewMode: SplitViewMode.Horizontal,
-                view1: DefaultArtifactDetailCard(),
-                view2: ArtifactDetailCard(editable: true),
-              ),
+              child: ArtifactDetailCard(editable: true),
             ),
             BottomBar(),
           ],

--- a/viewer/lib/pages/artifact_list.dart
+++ b/viewer/lib/pages/artifact_list.dart
@@ -81,6 +81,7 @@ class _ArtifactListPageState extends State<ArtifactListPage> {
               },
               artifactService,
               pageLoadController,
+              true,
             ),
           ),
         ),

--- a/viewer/lib/pages/deployment_detail.dart
+++ b/viewer/lib/pages/deployment_detail.dart
@@ -67,11 +67,15 @@ class DeploymentDetailPage extends StatelessWidget {
                   children: [
                     DeploymentDetailCard(editable: true),
                     narrow(context)
-                        ? ArtifactListCard(SelectionProvider.deployment)
+                        ? ArtifactListCard(
+                            SelectionProvider.deployment,
+                            singleColumn: true,
+                          )
                         : CustomSplitView(
                             viewMode: SplitViewMode.Horizontal,
-                            view1:
-                                ArtifactListCard(SelectionProvider.deployment),
+                            view1: ArtifactListCard(
+                                SelectionProvider.deployment,
+                                singleColumn: false),
                             view2: ArtifactDetailCard(
                               selflink: true,
                               editable: true,

--- a/viewer/lib/pages/deployment_list.dart
+++ b/viewer/lib/pages/deployment_list.dart
@@ -81,6 +81,7 @@ class _DeploymentListPageState extends State<DeploymentListPage> {
               },
               deploymentService,
               pageLoadController,
+              true,
             ),
           ),
         ),

--- a/viewer/lib/pages/project_detail.dart
+++ b/viewer/lib/pages/project_detail.dart
@@ -69,22 +69,28 @@ class ProjectDetailPage extends StatelessWidget {
                   children: [
                     ProjectDetailCard(editable: (root() == "/")),
                     narrow(context)
-                        ? ApiListCard()
+                        ? ApiListCard(singleColumn: true)
                         : CustomSplitView(
                             viewMode: SplitViewMode.Horizontal,
                             initialWeight: 0.33,
-                            view1: ApiListCard(),
+                            view1: ApiListCard(singleColumn: false),
                             view2: ApiDetailCard(
                               selflink: true,
                               editable: true,
                             ),
                           ),
                     narrow(context)
-                        ? ArtifactListCard(SelectionProvider.project)
+                        ? ArtifactListCard(
+                            SelectionProvider.project,
+                            singleColumn: true,
+                          )
                         : CustomSplitView(
                             viewMode: SplitViewMode.Horizontal,
                             initialWeight: 0.5,
-                            view1: ArtifactListCard(SelectionProvider.project),
+                            view1: ArtifactListCard(
+                              SelectionProvider.project,
+                              singleColumn: false,
+                            ),
                             view2: ArtifactDetailCard(
                               selflink: true,
                               editable: true,

--- a/viewer/lib/pages/project_list.dart
+++ b/viewer/lib/pages/project_list.dart
@@ -69,6 +69,7 @@ class _ProjectListPageState extends State<ProjectListPage> {
             },
             projectService,
             pageLoadController,
+            true,
           ),
         ),
       ),

--- a/viewer/lib/pages/spec_detail.dart
+++ b/viewer/lib/pages/spec_detail.dart
@@ -71,10 +71,16 @@ class SpecDetailPage extends StatelessWidget {
                   SpecDetailCard(editable: true),
                   SpecFileCard(),
                   narrow(context)
-                      ? ArtifactListCard(SelectionProvider.spec)
+                      ? ArtifactListCard(
+                          SelectionProvider.spec,
+                          singleColumn: true,
+                        )
                       : CustomSplitView(
                           viewMode: SplitViewMode.Horizontal,
-                          view1: ArtifactListCard(SelectionProvider.spec),
+                          view1: ArtifactListCard(
+                            SelectionProvider.spec,
+                            singleColumn: false,
+                          ),
                           view2: ArtifactDetailCard(
                             selflink: true,
                             editable: true,

--- a/viewer/lib/pages/spec_list.dart
+++ b/viewer/lib/pages/spec_list.dart
@@ -82,6 +82,7 @@ class _SpecListPageState extends State<SpecListPage> {
               },
               specService,
               pageLoadController,
+              true,
             ),
           ),
         ),

--- a/viewer/lib/pages/version_detail.dart
+++ b/viewer/lib/pages/version_detail.dart
@@ -70,19 +70,29 @@ class VersionDetailPage extends StatelessWidget {
                   children: [
                     VersionDetailCard(editable: true),
                     narrow(context)
-                        ? SpecListCard()
+                        ? SpecListCard(
+                            singleColumn: true,
+                          )
                         : CustomSplitView(
                             viewMode: SplitViewMode.Horizontal,
                             initialWeight: 0.33,
-                            view1: SpecListCard(),
+                            view1: SpecListCard(
+                              singleColumn: false,
+                            ),
                             view2:
                                 SpecDetailCard(selflink: true, editable: true),
                           ),
                     narrow(context)
-                        ? ArtifactListCard(SelectionProvider.version)
+                        ? ArtifactListCard(
+                            SelectionProvider.version,
+                            singleColumn: true,
+                          )
                         : CustomSplitView(
                             viewMode: SplitViewMode.Horizontal,
-                            view1: ArtifactListCard(SelectionProvider.version),
+                            view1: ArtifactListCard(
+                              SelectionProvider.version,
+                              singleColumn: false,
+                            ),
                             view2: ArtifactDetailCard(
                               selflink: true,
                               editable: true,

--- a/viewer/lib/pages/version_list.dart
+++ b/viewer/lib/pages/version_list.dart
@@ -81,6 +81,7 @@ class _VersionListPageState extends State<VersionListPage> {
               },
               versionService,
               pageLoadController,
+              true,
             ),
           ),
         ),

--- a/viewer/lib/routes.dart
+++ b/viewer/lib/routes.dart
@@ -48,6 +48,7 @@ class RegistryRouter {
   RegistryRouter() {
     // build patterns
     const namePattern = r"([a-zA-Z0-9-_\.]+)";
+    const revisionPattern = r"(@[a-z0-9-]+)?";
     const projectsPattern = r"^/projects";
     const projectPattern = projectsPattern + r"/" + namePattern;
     const apisPattern = projectPattern + r"/locations/global/apis";
@@ -55,9 +56,10 @@ class RegistryRouter {
     const versionsPattern = apiPattern + r"/versions";
     const versionPattern = versionsPattern + r"/" + namePattern;
     const specsPattern = versionPattern + r"/specs";
-    const specPattern = specsPattern + r"/" + namePattern;
+    const specPattern = specsPattern + r"/" + namePattern + revisionPattern;
     const deploymentsPattern = apiPattern + r"/deployments";
-    const deploymentPattern = deploymentsPattern + r"/" + namePattern;
+    const deploymentPattern =
+        deploymentsPattern + r"/" + namePattern + revisionPattern;
     const artifactsPattern = r"((" +
         projectPattern +
         r"/locations/global)|(" +


### PR DESCRIPTION
This fixes problems displaying artifacts under specs and deployments that appeared when we started putting deployments under revisions. When the revision ids were added to the spec and deployment names, the pattern-matching in the "routing" part of the app failed to match artifacts under revisions.