### PR TITLE
Artifact text widgets

### DIFF
--- a/viewer/lib/components/api_detail.dart
+++ b/viewer/lib/components/api_detail.dart
@@ -17,6 +17,7 @@ import 'package:registry/registry.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:url_launcher/url_launcher.dart';
 import '../components/api_edit.dart';
+import '../components/artifact_text.dart';
 import '../components/detail_rows.dart';
 import '../components/dialog_builder.dart';
 import '../components/empty.dart';
@@ -181,6 +182,11 @@ class _ApiDetailCardState extends State<ApiDetailCard>
                       color: Theme.of(context).primaryColor,
                     ),
                     SizedBox(height: 10),
+                    ArtifactText(
+                      () =>
+                          SelectionProvider.of(context)!.apiName.value +
+                          "/artifacts/summary",
+                    ),
                     PageSection(
                       children: [
                         MarkdownBody(

--- a/viewer/lib/components/artifact_text.dart
+++ b/viewer/lib/components/artifact_text.dart
@@ -1,0 +1,86 @@
+// Copyright 2023 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:flutter/material.dart';
+import 'package:registry/registry.dart';
+import '../models/artifact.dart';
+import '../models/selection.dart';
+import '../service/registry.dart';
+
+// ArtifactText displays a text artifact.
+class ArtifactText extends StatefulWidget {
+  final String Function() artifactName;
+
+  ArtifactText(this.artifactName);
+  _ArtifactTextState createState() => _ArtifactTextState();
+}
+
+class _ArtifactTextState extends State<ArtifactText> {
+  ArtifactManager? artifactManager;
+  Selection? selection;
+
+  void managerListener() {
+    setState(() {});
+  }
+
+  void selectionListener() {
+    setState(() {
+      setArtifactName(
+        widget.artifactName(),
+      );
+    });
+  }
+
+  void setArtifactName(String name) {
+    if (artifactManager?.name == name) {
+      return;
+    }
+    // forget the old manager
+    artifactManager?.removeListener(managerListener);
+    // get the new manager
+    artifactManager = RegistryProvider.of(context)!.getArtifactManager(name);
+    artifactManager!.addListener(managerListener);
+    // get the value from the manager
+    managerListener();
+  }
+
+  @override
+  void didChangeDependencies() {
+    selection = SelectionProvider.of(context);
+    selection!.artifactName.addListener(selectionListener);
+    super.didChangeDependencies();
+    selectionListener();
+  }
+
+  @override
+  void dispose() {
+    artifactManager?.removeListener(managerListener);
+    selection!.artifactName.removeListener(selectionListener);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (artifactManager?.value == null) {
+      return Container();
+    }
+
+    Artifact artifact = artifactManager!.value!;
+    return Text(
+      artifact.stringValue,
+      textAlign: TextAlign.left,
+      style: Theme.of(context).textTheme.titleSmall!,
+    );
+  }
+}

--- a/viewer/lib/components/deployment_detail.dart
+++ b/viewer/lib/components/deployment_detail.dart
@@ -14,6 +14,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:registry/registry.dart';
+import '../components/artifact_text.dart';
 import '../components/detail_rows.dart';
 import '../components/dialog_builder.dart';
 import '../components/deployment_edit.dart';
@@ -184,6 +185,11 @@ class _DeploymentDetailCardState extends State<DeploymentDetailCard>
                       color: Theme.of(context).primaryColor,
                     ),
                     SizedBox(height: 10),
+                    ArtifactText(
+                      () =>
+                          SelectionProvider.of(context)!.deploymentName.value +
+                          "/artifacts/summary",
+                    ),
                     if (deployment.description != "")
                       PageSection(
                         children: [

--- a/viewer/lib/components/project_detail.dart
+++ b/viewer/lib/components/project_detail.dart
@@ -16,6 +16,7 @@ import 'package:flutter/material.dart';
 import 'package:registry/registry.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:url_launcher/url_launcher.dart';
+import '../components/artifact_text.dart';
 import '../components/detail_rows.dart';
 import '../components/dialog_builder.dart';
 import '../components/empty.dart';
@@ -162,6 +163,11 @@ class _ProjectDetailCardState extends State<ProjectDetailCard>
                       color: Theme.of(context).primaryColor,
                     ),
                     SizedBox(height: 10),
+                    ArtifactText(
+                      () =>
+                          SelectionProvider.of(context)!.projectName.value +
+                          "/locations/global/artifacts/summary",
+                    ),
                     PageSection(
                       children: [
                         MarkdownBody(

--- a/viewer/lib/components/spec_detail.dart
+++ b/viewer/lib/components/spec_detail.dart
@@ -15,6 +15,7 @@
 import 'package:flutter/material.dart';
 import 'package:registry/registry.dart';
 import 'package:google_fonts/google_fonts.dart';
+import '../components/artifact_text.dart';
 import '../components/detail_rows.dart';
 import '../components/dialog_builder.dart';
 import '../components/spec_edit.dart';
@@ -219,6 +220,11 @@ class _SpecDetailCardState extends State<SpecDetailCard>
                       color: Theme.of(context).primaryColor,
                     ),
                     SizedBox(height: 10),
+                    ArtifactText(
+                      () =>
+                          SelectionProvider.of(context)!.specName.value +
+                          "/artifacts/summary",
+                    ),
                     if (spec.description != "")
                       PageSection(
                         children: [

--- a/viewer/lib/components/version_detail.dart
+++ b/viewer/lib/components/version_detail.dart
@@ -14,6 +14,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:registry/registry.dart';
+import '../components/artifact_text.dart';
 import '../components/detail_rows.dart';
 import '../components/dialog_builder.dart';
 import '../components/empty.dart';
@@ -192,6 +193,11 @@ class _VersionDetailCardState extends State<VersionDetailCard>
                       color: Theme.of(context).primaryColor,
                     ),
                     SizedBox(height: 10),
+                    ArtifactText(
+                      () =>
+                          SelectionProvider.of(context)!.versionName.value +
+                          "/artifacts/summary",
+                    ),
                     if (version.description != "")
                       PageSection(
                         children: [


### PR DESCRIPTION
This contains a proof-of-concept that shows how artifacts can be used to cause custom elements to appear in views. It includes a new `ArtifactText` widget that can be configured to look for a specified artifact and if that artifact is present, display its contents in a text box. Providing richer formatted views would be a relatively easy follow-on.

Here is an example that displays a YAML file attached to a project:
![image](https://user-images.githubusercontent.com/405/217712842-dd4fc407-28cd-4c3b-88c6-bcc1e1b8dbe6.png)

This YAML file is stored in the registry in an artifact named `summary`:
```
$ registry get artifacts/summary -o yaml
apiVersion: apigeeregistry/v1
kind: Summary
metadata:
  name: summary
data:
  apiCount: 2658
  versionCount: 4255
  specCount: 4473
  awesomeness: off the charts!
```

This PR adds "summary" views to the detail cards for projects, APIs, versions, specs, and deployments.