### PR TITLE
Remove "no $kind selected" message from default detail background.

### DIFF
--- a/viewer/lib/components/api_detail.dart
+++ b/viewer/lib/components/api_detail.dart
@@ -82,7 +82,7 @@ class _ApiDetailCardState extends State<ApiDetailCard>
   Widget build(BuildContext context) {
     super.build(context);
     if (apiManager?.value == null) {
-      return emptyCard(context, "api");
+      return emptyCard(context);
     }
 
     Function? selflink = onlyIf(widget.selflink, () {

--- a/viewer/lib/components/artifact_detail.dart
+++ b/viewer/lib/components/artifact_detail.dart
@@ -85,7 +85,7 @@ class _ArtifactDetailCardState extends State<ArtifactDetailCard>
   Widget build(BuildContext context) {
     super.build(context);
     if (artifactManager?.value == null) {
-      return emptyCard(context, "artifact");
+      return emptyCard(context);
     }
 
     Function? selflink = onlyIf(widget.selflink, () {

--- a/viewer/lib/components/deployment_detail.dart
+++ b/viewer/lib/components/deployment_detail.dart
@@ -97,7 +97,7 @@ class _DeploymentDetailCardState extends State<DeploymentDetailCard>
   Widget build(BuildContext context) {
     super.build(context);
     if (deploymentManager?.value == null) {
-      return emptyCard(context, "deployment");
+      return emptyCard(context);
     }
 
     Function? selflink = onlyIf(widget.selflink, () {

--- a/viewer/lib/components/empty.dart
+++ b/viewer/lib/components/empty.dart
@@ -17,7 +17,6 @@ import 'package:flutter/material.dart';
 Card emptyCard(BuildContext context, String kind) {
   return Card(
     child: Container(
-      child: Center(child: Text("no $kind selected")),
       color: Theme.of(context).canvasColor,
     ),
   );

--- a/viewer/lib/components/empty.dart
+++ b/viewer/lib/components/empty.dart
@@ -14,7 +14,7 @@
 
 import 'package:flutter/material.dart';
 
-Card emptyCard(BuildContext context, String kind) {
+Card emptyCard(BuildContext context) {
   return Card(
     child: Container(
       color: Theme.of(context).canvasColor,

--- a/viewer/lib/components/project_detail.dart
+++ b/viewer/lib/components/project_detail.dart
@@ -82,7 +82,7 @@ class _ProjectDetailCardState extends State<ProjectDetailCard>
   Widget build(BuildContext context) {
     super.build(context);
     if (projectManager?.value == null) {
-      return emptyCard(context, "project");
+      return emptyCard(context);
     }
 
     Function? selflink = onlyIf(widget.selflink, () {

--- a/viewer/lib/components/spec_detail.dart
+++ b/viewer/lib/components/spec_detail.dart
@@ -115,7 +115,7 @@ class _SpecDetailCardState extends State<SpecDetailCard>
   Widget build(BuildContext context) {
     super.build(context);
     if (specManager?.value == null) {
-      return emptyCard(context, "spec");
+      return emptyCard(context);
     }
 
     Function? selflink = onlyIf(widget.selflink, () {

--- a/viewer/lib/components/version_detail.dart
+++ b/viewer/lib/components/version_detail.dart
@@ -96,7 +96,7 @@ class _VersionDetailCardState extends State<VersionDetailCard>
   Widget build(BuildContext context) {
     super.build(context);
     if (versionManager?.value == null) {
-      return emptyCard(context, "version");
+      return emptyCard(context);
     }
 
     Function? selflink = onlyIf(widget.selflink, () {

--- a/viewer/lib/generated_plugin_registrant.dart
+++ b/viewer/lib/generated_plugin_registrant.dart
@@ -1,0 +1,18 @@
+//
+// Generated file. Do not edit.
+//
+
+// ignore_for_file: directives_ordering
+// ignore_for_file: lines_longer_than_80_chars
+
+import 'package:google_sign_in_web/google_sign_in_web.dart';
+import 'package:url_launcher_web/url_launcher_web.dart';
+
+import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+
+// ignore: public_member_api_docs
+void registerPlugins(Registrar registrar) {
+  GoogleSignInPlugin.registerWith(registrar);
+  UrlLauncherPlugin.registerWith(registrar);
+  registrar.registerMessageHandler();
+}


### PR DESCRIPTION
Because detail views often display this message when loading, this removes the "no $kind selected" message because it is incorrect and misleading.

This is what is changing; with this PR, the area on the right will be empty:
![image](https://user-images.githubusercontent.com/405/218226322-dd16c06d-493d-4f80-bee5-0865d3b9c898.png)
