### PR TITLE
Adjust dividers to avoid displaying them around empty sections.

### DIFF
--- a/viewer/lib/components/api_detail.dart
+++ b/viewer/lib/components/api_detail.dart
@@ -135,11 +135,11 @@ class ApiDetailCardState extends State<ApiDetailCard>
                         AnnotationsRow(api.annotations),
                       ]),
                     const SizedBox(height: 10),
-                    Divider(
-                      color: Theme.of(context).primaryColor,
-                    ),
                     ArtifactSection(
                       () => SelectionProvider.of(context)!.apiName.value,
+                    ),
+                    Divider(
+                      color: Theme.of(context).primaryColor,
                     ),
                     MarkdownBody(
                       data: api.description,

--- a/viewer/lib/components/artifact_section.dart
+++ b/viewer/lib/components/artifact_section.dart
@@ -81,6 +81,10 @@ class ArtifactSectionState extends State<ArtifactSection> {
 
     List<Artifact> artifacts = artifactListManager!.value!.artifacts;
     return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+      if (artifacts.isNotEmpty)
+        Divider(
+          color: Theme.of(context).primaryColor,
+        ),
       for (var a in artifacts)
         if (kind(a.mimeType) == "FieldSet") ArtifactFieldSetCard(() => a.name),
       for (var a in artifacts)
@@ -99,9 +103,6 @@ class ArtifactSectionState extends State<ArtifactSection> {
               Text(kind(a.mimeType)),
             ]),
         ]),
-      Divider(
-        color: Theme.of(context).primaryColor,
-      ),
     ]);
   }
 }

--- a/viewer/lib/components/project_detail.dart
+++ b/viewer/lib/components/project_detail.dart
@@ -132,9 +132,6 @@ class ProjectDetailCardState extends State<ProjectDetailCard>
                       },
                     ),
                     const SizedBox(height: 10),
-                    Divider(
-                      color: Theme.of(context).primaryColor,
-                    ),
                     ArtifactSection(
                       () =>
                           "${SelectionProvider.of(context)!.projectName.value}/locations/global",


### PR DESCRIPTION
This makes a minor adjustment to the placement of dividers in project and API detail views:

<img width="859" alt="image" src="https://user-images.githubusercontent.com/405/225407024-06c024e3-bfac-40ec-ba15-a0906e49c3dc.png">

becomes 

<img width="789" alt="image" src="https://user-images.githubusercontent.com/405/225407252-158c8f24-82e0-4ebf-92a5-64032698106e.png">

