### PR TITLE
Disable Mac sandbox

### DIFF
--- a/viewer/macos/Runner/DebugProfile.entitlements
+++ b/viewer/macos/Runner/DebugProfile.entitlements
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<true/>
+	<false/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.server</key>


### PR DESCRIPTION
Since the viewer looks for registry configuration in `$HOME/.config/registry`, it needs to see outside the Mac application sandbox. Disabling the sandbox is the easiest way to do that. (Finer-grained solutions would be welcome!)